### PR TITLE
[k8sops] move readiness probes to new script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/pkg/client/clientset/**   linguist-generated=true
+/pkg/client/listers/**     linguist-generated=true
+/pkg/client/informers/**   linguist-generated=true
+*zz_generated*.go         linguist-generated=true

--- a/pkg/k8sops/generators.go
+++ b/pkg/k8sops/generators.go
@@ -43,9 +43,7 @@ const (
 	// https://github.com/m3db/m3/issues/996
 	_probePort       = 7201
 	_probePathHealth = "/health"
-	_probePathReady  = "/bootstrapped"
 
-	_baseImage              = "quay.io/m3/m3dbnode:latest"
 	_dataDirectory          = "/var/lib/m3db/"
 	_configurationDirectory = "/etc/m3db/"
 	_configurationName      = "m3-configuration"

--- a/pkg/k8sops/generators_test.go
+++ b/pkg/k8sops/generators_test.go
@@ -89,10 +89,8 @@ func TestGenerateStatefulSet(t *testing.T) {
 		InitialDelaySeconds: _probeInitialDelaySeconds,
 		FailureThreshold:    _probeFailureThreshold,
 		Handler: v1.Handler{
-			HTTPGet: &v1.HTTPGetAction{
-				Port:   intstr.FromInt(_probePort),
-				Path:   _probePathHealth,
-				Scheme: v1.URISchemeHTTP,
+			Exec: &v1.ExecAction{
+				Command: []string{_healthFileName},
 			},
 		},
 	}


### PR DESCRIPTION
As of https://github.com/m3db/m3/pull/997 we have a more accurate method
of checking whether a node is bootstrapped.