### PR TITLE
Create pkg for kubernetes events

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -5,4 +5,4 @@ set -exuo pipefail
 export PACKAGE=github.com/m3db/m3db-operator
 
 git submodule update --init --recursive
-make clean-all test-ci-unit test-all-gen
+make clean-all test-ci-unit lint test-all-gen

--- a/.excludecoverage
+++ b/.excludecoverage
@@ -1,2 +1,5 @@
 _mock.go
 vendor/
+_tools/
+zz_generated.deepcopy.go
+pkg/apis/client/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### GKE
 When running on GKE, the user applying the manifests will need the ability to
 allow `cluster-admin-binding` during the installation. Use the following
-`ClusterRoleBinding` with the user name provided by gloud
+`ClusterRoleBinding` with the user name provided by gcloud
 
 ```
 kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=<name@domain.com>
@@ -125,7 +125,7 @@ coordinator, which it must do in order to create placements and namespaces:
 
 To allow communication between your local operator and the cluster, you can `kubectl port-forward` to the coordinator:
 ```
-$ kubectl port-forward -n m3db svc/m3coordinator-m3db-cluster 7201
+$ kubectl port-forward  svc/m3coordinator-m3db-cluster 7201
 Forwarding from 127.0.0.1:7201 -> 7201
 Forwarding from [::1]:7201 -> 7201
 ```
@@ -150,7 +150,7 @@ $ kubectl exec etcd-0 -- env ETCDCTL_API=3 etcdctl del --prefix ""
 Delete M3DB Operator
 
 ```
-kubectrl delete -f manifests/operator.yaml
+kubectl delete -f manifests/operator.yaml
 ```
 
 ### Help

--- a/pkg/controller/add_cluster.go
+++ b/pkg/controller/add_cluster.go
@@ -34,6 +34,7 @@ import (
 	"github.com/m3db/m3x/ident"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/m3db/m3db-operator/pkg/util/eventer"
 	"go.uber.org/zap"
 )
 
@@ -138,11 +139,10 @@ func (c *Controller) ensureServices(cluster *myspec.M3DBCluster) error {
 	services = append(services, m3dbSvc)
 
 	for _, svc := range services {
-		err := c.k8sclient.EnsureService(cluster, svc)
+		err = c.k8sclient.EnsureService(cluster, svc)
 		if err != nil {
 			err := fmt.Errorf("error creating service '%s': %v", svc.Name, err)
-			c.logger.Error(err.Error())
-			c.recorder.Event(cluster, corev1.EventTypeWarning, "ServiceCreateError", err.Error())
+			c.recorder.WarningEvent(cluster, eventer.ReasonFailedCreate, err.Error())
 			return err
 		}
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -177,7 +177,7 @@ func New(opts ...Option) (*Controller, error) {
 
 		workQueue: workQueue,
 		// TODO(celina): figure out if we actually need a recorder for each namespace
-		recorder: eventer.NewEventRecorder(kubeClient, logger, "", _controllerName),
+		recorder: eventer.NewEventRecorder(kubeClient, eventer.WithLogger(logger), eventer.WithComponent(_controllerName)),
 	}
 
 	m3dbClusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/controller/update_cluster.go
+++ b/pkg/controller/update_cluster.go
@@ -32,6 +32,7 @@ import (
 	myspec "github.com/m3db/m3db-operator/pkg/apis/m3dboperator/v1"
 	"github.com/m3db/m3db-operator/pkg/m3admin"
 
+	"github.com/m3db/m3db-operator/pkg/util/eventer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -50,7 +51,7 @@ func (c *Controller) validateNamespaceWithStatus(cluster *myspec.M3DBCluster) (b
 	if err != nil {
 		err = fmt.Errorf("error creating namespace: %v", err)
 		c.logger.Error(err.Error())
-		c.recorder.Event(cluster, corev1.EventTypeWarning, "NamespaceCreateError", err.Error())
+		c.recorder.WarningEvent(cluster, eventer.ReasonFailedCreate, err.Error())
 		return false, err
 	}
 
@@ -71,6 +72,8 @@ func (c *Controller) validateNamespaceWithStatus(cluster *myspec.M3DBCluster) (b
 		Reason:  "NamespaceCreated",
 		Message: "Created namespace",
 	})
+
+	c.recorder.NormalEvent(cluster, eventer.ReasonSuccessfulCreate, "Namespace created")
 
 	_, err = c.crdClient.OperatorV1().M3DBClusters(cluster.Namespace).Update(cluster)
 	if err != nil {

--- a/pkg/util/eventer/eventer.go
+++ b/pkg/util/eventer/eventer.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package eventer
+
+import (
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+// Types of kubernetes emitted events
+const (
+
+	// Add events
+	ReasonAdding        = "Adding"
+	ReasonFailedToAdd   = "FailedToAdd"
+	ReasonSuccessfulAdd = "SuccessfulAdd"
+
+	// Delete events
+	ReasonDeleting         = "Deleting"
+	ReasonFailedToDelete   = "FailedToDelete"
+	ReasonSuccessfulDelete = "SuccessfulDelete"
+
+	// Create events
+	ReasonCreating         = "Creating"
+	ReasonFailedCreate     = "FailedToCreate"
+	ReasonSuccessfulCreate = "SuccessfulCreate"
+
+	// Update events
+	ReasonUpdating         = "Updating"
+	ReasonFailedToUpdate   = "FailedToUpdate"
+	ReasonSuccessfulUpdate = "SuccessfulUpdate"
+
+	// Sync events
+	ReasonSyncing     = "Syncing"
+	ReasonSuccessSync = "FailedToSync"
+	ReasonFailSync    = "SuccessfulSync"
+
+	// Misc events
+	ReasonLongerThanUsual = "TimeLongerThanUsual"
+	ReasonUnknown         = "Unknown"
+)
+
+// Poster posts events accordingly to kind of behavior
+type Poster interface {
+	NormalEvent(object runtime.Object, reason, message string)
+	WarningEvent(object runtime.Object, reason, message string, args ...interface{})
+}
+
+type eventer struct {
+	recorder record.EventRecorder
+}
+
+// NewEventRecorder creates a new recorder to emit kubernetes events.
+func NewEventRecorder(
+	kubeClient kubernetes.Interface,
+	logger *zap.Logger,
+	namespace, component string) Poster {
+
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartLogging(logger.Sugar().Infof)
+	broadcaster.StartRecordingToSink(
+		&typedcorev1.EventSinkImpl{
+			Interface: kubeClient.CoreV1().Events(namespace)})
+
+	return &eventer{
+		recorder: broadcaster.NewRecorder(
+			scheme.Scheme,
+			corev1.EventSource{Component: component}),
+	}
+}
+
+// NormalEvent posts an event of expected healthy behavior
+func (e *eventer) NormalEvent(object runtime.Object, reason, message string) {
+	e.recorder.Event(object,
+		corev1.EventTypeNormal,
+		reason,
+		message)
+}
+
+// WarningEvent post an event of type errors or unexpectled possibly unhealthy behavior
+func (e *eventer) WarningEvent(object runtime.Object, reason, message string, args ...interface{}) {
+	e.recorder.Eventf(object,
+		corev1.EventTypeWarning,
+		reason,
+		message,
+		args)
+}

--- a/pkg/util/eventer/eventer_test.go
+++ b/pkg/util/eventer/eventer_test.go
@@ -55,7 +55,11 @@ func TestWarningEvent(t *testing.T) {
 }
 
 func testNewEventRecorder(t *testing.T) Poster {
-	testEventer := NewEventRecorder(kubeFake.NewSimpleClientset(), zap.NewNop(), "test", "testy")
+	testEventer := NewEventRecorder(
+		kubeFake.NewSimpleClientset(),
+		WithLogger(zap.NewNop()),
+		WithNamespace("test"),
+		WithComponent("testy"))
 	require.NotNil(t, testEventer)
 	return testEventer
 }

--- a/pkg/util/eventer/options.go
+++ b/pkg/util/eventer/options.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package eventer
+
+import "go.uber.org/zap"
+
+// Option provides configuration of an eventer.
+type Option interface {
+	execute(*options)
+}
+
+type options struct {
+	logger    *zap.Logger
+	namespace string
+	component string
+}
+
+type optionFn func(o *options)
+
+func (fn optionFn) execute(o *options) {
+	fn(o)
+}
+
+// WithLogger sets a logger for the eventer. If not set a noop logger will
+// be used.
+func WithLogger(l *zap.Logger) Option {
+	return optionFn(func(o *options) {
+		o.logger = l
+	})
+}
+
+// WithNamespace sets a namespace for the eventer.
+func WithNamespace(ns string) Option {
+	return optionFn(func(o *options) {
+		o.namespace = ns
+	})
+}
+
+// WithComponent sets a component for the eventer.
+func WithComponent(c string) Option {
+	return optionFn(func(o *options) {
+		o.component = c
+	})
+}


### PR DESCRIPTION
Issue #26 

## Why?

- standardize kubernetes events in terms of our operator to actually be informative to the user
- Initialized events recorder package with some starter event reasons (subject to change ofc)

##  What changed?

- moved the `k8.io/client-go/tools/record` to the `util/eventer`directory
- replaced existing `c.recorder` lines with the new `eventer.Post....`lines
- removed some `c.logger` lines where i added the new `eventer` lines because the logger is passed in, this might be incorrect though so please review 

## What's next? 
- re-scope the EventReasons
- add `eventer.Post...` to wherever we see fit as we make updates to this repo 
- write a test for `eventer.go` provided it is agreed upon