### PR TITLE
[controller] support instance removes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# m3db-operator [![e2e](https://travis-ci.org/m3db/m3db-operator.svg?branch=master)](https://travis-ci.org/m3db/m3db-operator)  [![Build Status](https://semaphoreci.com/api/v1/m3db/m3db-operator/branches/master/badge.svg)](https://semaphoreci.com/m3db/m3db-operator) [![codecov](https://codecov.io/gh/m3db/m3db-operator/branch/master/graph/badge.svg)](https://codecov.io/gh/m3db/m3db-operator)
+# m3db-operator [![e2e](https://travis-ci.org/m3db/m3db-operator.svg?branch=master)](https://travis-ci.org/m3db/m3db-operator)  [![Build status](https://badge.buildkite.com/6cf88054469d7d59a584f618426dc2bd436f816daaf5000db8.svg)](https://buildkite.com/m3/m3db-operator) [![codecov](https://codecov.io/gh/m3db/m3db-operator/branch/master/graph/badge.svg)](https://codecov.io/gh/m3db/m3db-operator)
 
 ## Project Status: pre-Alpha
 

--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package controller
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	crdfake "github.com/m3db/m3db-operator/pkg/client/clientset/versioned/fake"
+	crdinformers "github.com/m3db/m3db-operator/pkg/client/informers/externalversions"
+	crdlisters "github.com/m3db/m3db-operator/pkg/client/listers/m3dboperator/v1"
+	"github.com/m3db/m3db-operator/pkg/m3admin/namespace"
+	"github.com/m3db/m3db-operator/pkg/m3admin/placement"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/clock"
+	kubeinformers "k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
+)
+
+type testOpts struct {
+	kubeObjects     []runtime.Object
+	crdObjects      []runtime.Object
+	clock           clock.Clock
+	placementClient placement.Client
+	namespaceClient namespace.Client
+}
+
+type testDeps struct {
+	kubeClient        *kubefake.Clientset
+	crdClient         *crdfake.Clientset
+	statefulSetLister appsv1listers.StatefulSetLister
+	podLister         corev1listers.PodLister
+	crdLister         crdlisters.M3DBClusterLister
+	placementClient   placement.Client
+	namespaceClient   namespace.Client
+	clock             clock.Clock
+	stopCh            chan struct{}
+	closed            int32
+}
+
+func (deps *testDeps) newController() *Controller {
+	return &Controller{
+		logger: zap.NewNop(),
+		scope:  tally.NoopScope,
+		clock:  deps.clock,
+
+		kubeClient: deps.kubeClient,
+		crdClient:  deps.crdClient,
+
+		clusterLister:     deps.crdLister,
+		statefulSetLister: deps.statefulSetLister,
+		podLister:         deps.podLister,
+
+		placementClient: deps.placementClient,
+		namespaceClient: deps.namespaceClient,
+	}
+}
+
+func (deps *testDeps) cleanup() {
+	if atomic.CompareAndSwapInt32(&deps.closed, 0, 1) {
+		close(deps.stopCh)
+	}
+}
+
+func newTestDeps(t *testing.T, opts *testOpts) *testDeps {
+	deps := &testDeps{
+		kubeClient:      kubefake.NewSimpleClientset(opts.kubeObjects...),
+		crdClient:       crdfake.NewSimpleClientset(opts.crdObjects...),
+		clock:           opts.clock,
+		stopCh:          make(chan struct{}),
+		placementClient: opts.placementClient,
+		namespaceClient: opts.namespaceClient,
+	}
+
+	if deps.clock == nil {
+		deps.clock = clock.NewFakeClock(time.Now())
+	}
+
+	kubeInformers := kubeinformers.NewSharedInformerFactory(deps.kubeClient, 0)
+	sets := kubeInformers.Apps().V1().StatefulSets()
+	pods := kubeInformers.Core().V1().Pods()
+
+	crdInformers := crdinformers.NewSharedInformerFactory(deps.crdClient, 0)
+	crds := crdInformers.Operator().V1().M3DBClusters()
+
+	deps.statefulSetLister = sets.Lister()
+	deps.podLister = pods.Lister()
+	deps.crdLister = crds.Lister()
+
+	go kubeInformers.Start(deps.stopCh)
+	go crdInformers.Start(deps.stopCh)
+
+	warmCh := make(chan bool)
+	go func() {
+		warmCh <- cache.WaitForCacheSync(deps.stopCh,
+			sets.Informer().HasSynced,
+			pods.Informer().HasSynced,
+			crds.Informer().HasSynced,
+		)
+	}()
+
+	select {
+	case success := <-warmCh:
+		require.True(t, success)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for informer cache")
+	}
+
+	return deps
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -450,7 +450,7 @@ func (c *Controller) handleClusterUpdate(cluster *myspec.M3DBCluster) error {
 	}
 
 	if len(unavailInsts) > 0 {
-		c.logger.Info("waiting for instances to be available", zap.Strings("instances", unavailInsts))
+		c.logger.Warn("waiting for instances to be available", zap.Strings("instances", unavailInsts))
 		return nil
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -38,6 +38,8 @@ import (
 	"github.com/m3db/m3db-operator/pkg/m3admin/placement"
 	"github.com/m3db/m3db-operator/pkg/util/eventer"
 
+	m3placement "github.com/m3db/m3cluster/placement"
+
 	appsv1 "k8s.io/api/apps/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -440,15 +442,16 @@ func (c *Controller) handleClusterUpdate(cluster *myspec.M3DBCluster) error {
 
 	c.logger.Info("found placement", zap.Int("currentPods", len(pods)), zap.Int("placementInsts", placement.NumInstances()))
 
-	if placement.NumInstances() < len(pods) {
-		for _, pod := range pods {
-			_, ok := placement.Instance(pod.Name)
-			if !ok {
-				// We want pod adds to restart the event loop to run regular sanity
-				// checks.
-				return c.addPodToPlacement(cluster, pod, placement)
-			}
+	unavailInsts := []string{}
+	for _, inst := range placement.Instances() {
+		if !inst.IsAvailable() {
+			unavailInsts = append(unavailInsts, inst.ID())
 		}
+	}
+
+	if len(unavailInsts) > 0 {
+		c.logger.Info("waiting for instances to be available", zap.Strings("instances", unavailInsts))
+		return nil
 	}
 
 	// Determine if any sets aren't at their desired replica count. Maybe we can
@@ -475,17 +478,46 @@ func (c *Controller) handleClusterUpdate(cluster *myspec.M3DBCluster) error {
 
 		desired := group.NumInstances
 		current := *set.Spec.Replicas
+		inPlacement := int32(len(instancesInIsoGroup(placement, group.Name)))
 
-		if current >= desired {
-			continue
+		setLogger := c.logger.With(
+			zap.String("statefulSet", set.Name),
+			zap.Int32("inPlacement", inPlacement),
+			zap.Int32("current", current),
+			zap.Int32("desired", desired),
+		)
+
+		if desired == current {
+			// If the set is at its desired size, and all pods in the set are in the
+			// placement, there's nothing we need to do for this set.
+			if current == inPlacement {
+				continue
+			}
+
+			// If the set is at its desired size but there's pods in the set that are
+			// absent from the placement, add pods to placement.
+			if inPlacement < current {
+				setLogger.Info("expanding placement for set")
+				return c.expandPlacementForSet(cluster, set, group, placement)
+			}
 		}
 
-		c.logger.Info("need to expand set, desired < current",
-			zap.String("set", set.Name),
-			zap.Int32("desired", desired),
-			zap.Int32("current", current))
+		// If there are more pods in the placement than we want in the group,
+		// trigger a remove so that we can shrink the set.
+		if inPlacement > desired {
+			setLogger.Info("remove instance from placement for set")
+			return c.shrinkPlacementForSet(cluster, set)
+		}
 
-		set.Spec.Replicas = pointer.Int32Ptr(current + 1)
+		var newCount int32
+		if current < desired {
+			newCount = current + 1
+		} else {
+			newCount = current - 1
+		}
+		setLogger.Info("resizing set, desired != current", zap.Int32("newSize", newCount))
+
+		set.Spec.Replicas = pointer.Int32Ptr(newCount)
 		set, err = c.kubeClient.AppsV1().StatefulSets(set.Namespace).Update(set)
 		if err != nil {
 			return fmt.Errorf("error updating statefulset %s: %v", set.Name, err)
@@ -511,8 +543,17 @@ func (c *Controller) handleClusterUpdate(cluster *myspec.M3DBCluster) error {
 		zap.Int64("generation", cluster.ObjectMeta.Generation),
 		zap.String("rv", cluster.ObjectMeta.ResourceVersion))
 
-	c.recorder.NormalEvent(cluster, eventer.ReasonSuccessfulUpdate, "Cluster update handled successfully")
 	return nil
+}
+
+func instancesInIsoGroup(pl m3placement.Placement, isoGroup string) []m3placement.Instance {
+	insts := []m3placement.Instance{}
+	for _, inst := range pl.Instances() {
+		if inst.IsolationGroup() == isoGroup {
+			insts = append(insts, inst)
+		}
+	}
+	return insts
 }
 
 // This func is currently read-only, but if we end up modifying statefulsets
@@ -569,5 +610,4 @@ func (c *Controller) handleStatefulSetUpdate(obj interface{}) {
 
 	// enqueue the cluster for processing
 	c.enqueueCluster(cluster)
-	c.recorder.NormalEvent(cluster, eventer.ReasonSuccessfulUpdate, "StatefulSet update handled successfully")
 }

--- a/pkg/controller/fixtures/cluster-3-zones.yaml
+++ b/pkg/controller/fixtures/cluster-3-zones.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: operator.m3db.io/v1
+kind: M3DBCluster
+metadata:
+  name: cluster-zones
+  namespace: fake
+spec:
+  image: foo/m3dbnode:latest
+  replicationFactor: 3
+  numberOfShards: 8
+  isolationGroups:
+    - name: us-fake1-a
+      numInstances: 3
+    - name: us-fake1-b
+      numInstances: 3
+    - name: us-fake1-c
+      numInstances: 3
+  resources:
+    requests:
+      memory: 1Gi
+      cpu: '1'
+    limits:
+      memory: 2Gi
+      cpu: '2'

--- a/pkg/controller/update_cluster_test.go
+++ b/pkg/controller/update_cluster_test.go
@@ -21,34 +21,39 @@
 package controller
 
 import (
+	"fmt"
+	"sort"
 	"testing"
 	"time"
 
 	myspec "github.com/m3db/m3db-operator/pkg/apis/m3dboperator/v1"
-	crdfake "github.com/m3db/m3db-operator/pkg/client/clientset/versioned/fake"
+	"github.com/m3db/m3db-operator/pkg/k8sops"
 	pkgplacement "github.com/m3db/m3db-operator/pkg/m3admin/placement"
 
 	"github.com/m3db/m3cluster/generated/proto/placementpb"
 	"github.com/m3db/m3cluster/placement"
 	"github.com/m3db/m3cluster/shard"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/clock"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSetPodBootstrappingStatus(t *testing.T) {
 	cluster := getFixture("cluster-simple.yaml", t)
 	assert.False(t, cluster.Status.HasPodBootstrapping())
 
-	controller := &Controller{
-		crdClient: crdfake.NewSimpleClientset(cluster),
-		clock:     clock.NewFakeClock(time.Now()),
-	}
+	deps := newTestDeps(t, &testOpts{
+		crdObjects: []runtime.Object{cluster},
+	})
+	controller := deps.newController()
+	defer deps.cleanup()
 
 	cluster, err := controller.setStatusPodBootstrapping(cluster, corev1.ConditionTrue, "foo", "bar")
 	assert.NoError(t, err)
@@ -60,10 +65,12 @@ func TestSetStatus(t *testing.T) {
 	cluster := getFixture("cluster-simple.yaml", t)
 
 	fakeClock := clock.NewFakeClock(time.Now())
-	controller := &Controller{
-		crdClient: crdfake.NewSimpleClientset(cluster),
-		clock:     fakeClock,
-	}
+	deps := newTestDeps(t, &testOpts{
+		crdObjects: []runtime.Object{cluster},
+		clock:      fakeClock,
+	})
+	controller := deps.newController()
+	defer deps.cleanup()
 
 	const cond = myspec.ClusterConditionNamespaceInitialized
 	cluster, err := controller.setStatus(cluster, cond, corev1.ConditionTrue, "foo", "bar")
@@ -95,10 +102,11 @@ func TestSetStatus(t *testing.T) {
 func TestReconcileBootstrappingStatus(t *testing.T) {
 	cluster := getFixture("cluster-simple.yaml", t)
 
-	controller := &Controller{
-		crdClient: crdfake.NewSimpleClientset(cluster),
-		clock:     clock.NewFakeClock(time.Now()),
-	}
+	deps := newTestDeps(t, &testOpts{
+		crdObjects: []runtime.Object{cluster},
+	})
+	controller := deps.newController()
+	defer deps.cleanup()
 
 	const cond = myspec.ClusterConditionPodBootstrapping
 
@@ -134,12 +142,12 @@ func TestAddPodToPlacement(t *testing.T) {
 	cluster := getFixture("cluster-simple.yaml", t)
 
 	placementMock := pkgplacement.NewMockClient(mc)
-	controller := &Controller{
-		crdClient:       crdfake.NewSimpleClientset(cluster),
+	deps := newTestDeps(t, &testOpts{
+		crdObjects:      []runtime.Object{cluster},
 		placementClient: placementMock,
-		logger:          zap.NewNop(),
-		clock:           clock.NewFakeClock(time.Now()),
-	}
+	})
+	controller := deps.newController()
+	defer deps.cleanup()
 
 	pl := placement.NewPlacement().SetReplicaFactor(1).SetMaxShardSetID(1)
 
@@ -171,4 +179,235 @@ func TestAddPodToPlacement(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.True(t, cluster.Status.HasPodBootstrapping())
+}
+
+func podsForClusterSet(cluster *myspec.M3DBCluster, set *appsv1.StatefulSet, numPods int) []*corev1.Pod {
+	pods := make([]*corev1.Pod, numPods)
+	for i := 0; i < numPods; i++ {
+		podName := fmt.Sprintf("%s-%d", set.Name, i)
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: cluster.Namespace,
+				Labels:    map[string]string{},
+			},
+		}
+		for k, v := range set.Labels {
+			pod.Labels[k] = v
+		}
+		pods[i] = pod
+	}
+	return pods
+}
+
+func objectsFromPods(pods ...*corev1.Pod) []runtime.Object {
+	arr := make([]runtime.Object, len(pods))
+	for i, pod := range pods {
+		arr[i] = pod
+	}
+	return arr
+}
+
+func placementFromPods(t *testing.T, cluster *myspec.M3DBCluster, pods []*corev1.Pod) placement.Placement {
+	insts := make([]placement.Instance, len(pods))
+	for i, pod := range pods {
+		instPb, err := k8sops.PlacementInstanceFromPod(cluster, pod)
+		require.NoError(t, err)
+		inst, err := placement.NewInstanceFromProto(instPb)
+		require.NoError(t, err)
+		insts[i] = inst
+	}
+	return placement.NewPlacement().SetInstances(insts)
+}
+
+func TestExpandPlacementForSet(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	cluster := getFixture("cluster-3-zones.yaml", t)
+
+	set, err := k8sops.GenerateStatefulSet(cluster, "us-fake1-a", 3)
+	require.NoError(t, err)
+	set.Status.ReadyReplicas = 3
+
+	pods := podsForClusterSet(cluster, set, 3)
+	pl := placementFromPods(t, cluster, pods[0:2])
+	group := cluster.Spec.IsolationGroups[0]
+
+	placementMock := pkgplacement.NewMockClient(mc)
+	deps := newTestDeps(t, &testOpts{
+		kubeObjects:     append(objectsFromPods(pods...)),
+		crdObjects:      []runtime.Object{cluster},
+		placementClient: placementMock,
+	})
+	controller := deps.newController()
+	defer deps.cleanup()
+
+	instPb, err := k8sops.PlacementInstanceFromPod(cluster, pods[2])
+	require.NoError(t, err)
+	placementMock.EXPECT().Add(*instPb)
+
+	err = controller.expandPlacementForSet(cluster, set, group, pl)
+	assert.NoError(t, err)
+
+	cluster, err = deps.crdClient.Operator().M3DBClusters(cluster.Namespace).Get(cluster.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.True(t, cluster.Status.HasPodBootstrapping())
+}
+
+func TestExpandPlacementForSet_Nop(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	cluster := getFixture("cluster-3-zones.yaml", t)
+
+	set, err := k8sops.GenerateStatefulSet(cluster, "us-fake1-a", 3)
+	require.NoError(t, err)
+
+	pods := podsForClusterSet(cluster, set, 3)
+	pl := placementFromPods(t, cluster, pods)
+	group := cluster.Spec.IsolationGroups[0]
+
+	placementMock := pkgplacement.NewMockClient(mc)
+	deps := newTestDeps(t, &testOpts{
+		placementClient: placementMock,
+	})
+	controller := deps.newController()
+	defer deps.cleanup()
+
+	err = controller.expandPlacementForSet(cluster, set, group, pl)
+	// We know this was a noop because the mock expects no calls.
+	assert.NoError(t, err)
+}
+
+func TestExpandPlacementForSet_Err(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	cluster := getFixture("cluster-3-zones.yaml", t)
+
+	set, err := k8sops.GenerateStatefulSet(cluster, "us-fake1-a", 3)
+	require.NoError(t, err)
+
+	pods := podsForClusterSet(cluster, set, 2)
+	pl := placementFromPods(t, cluster, pods)
+	group := cluster.Spec.IsolationGroups[0]
+
+	placementMock := pkgplacement.NewMockClient(mc)
+	deps := newTestDeps(t, &testOpts{
+		placementClient: placementMock,
+	})
+	controller := deps.newController()
+	defer deps.cleanup()
+
+	const expErr = "cannot expand set 'cluster-zones-rep0', not yet ready"
+	err = controller.expandPlacementForSet(cluster, set, group, pl)
+	assert.Equal(t, expErr, err.Error())
+}
+
+func TestShrinkPlacementForSet(t *testing.T) {
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+
+	cluster := getFixture("cluster-3-zones.yaml", t)
+
+	set, err := k8sops.GenerateStatefulSet(cluster, "us-fake1-a", 3)
+	require.NoError(t, err)
+
+	pods := podsForClusterSet(cluster, set, 3)
+
+	placementMock := pkgplacement.NewMockClient(mc)
+	deps := newTestDeps(t, &testOpts{
+		kubeObjects:     objectsFromPods(pods...),
+		placementClient: placementMock,
+	})
+	controller := deps.newController()
+	defer deps.cleanup()
+
+	placementMock.EXPECT().Remove(pods[2].Name)
+	err = controller.shrinkPlacementForSet(cluster, set)
+	assert.NoError(t, err)
+}
+
+func podWithName(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+func TestSortPodID(t *testing.T) {
+	for _, test := range []struct {
+		podIDs []podID
+		exp    []podID
+	}{
+		{
+			podIDs: []podID{{nil, 1}, {nil, 2}},
+			exp:    []podID{{nil, 1}, {nil, 2}},
+		},
+		{
+			podIDs: []podID{{nil, 2}, {nil, 1}},
+			exp:    []podID{{nil, 1}, {nil, 2}},
+		},
+	} {
+		podIDs := test.podIDs
+		sort.Sort(byPodID(podIDs))
+		assert.Equal(t, test.exp, podIDs)
+	}
+}
+
+func TestFindPodToRemove(t *testing.T) {
+	pods := []*corev1.Pod{}
+
+	_, err := findPodToRemove(pods)
+	assert.Error(t, err)
+
+	for _, s := range []string{
+		"",
+		"foo",
+		"foo-bar",
+	} {
+		pods = []*corev1.Pod{podWithName(s)}
+		_, err = findPodToRemove(pods)
+		assert.Error(t, err)
+	}
+
+	tests := []struct {
+		names  []string
+		exp    *corev1.Pod
+		expErr bool
+	}{
+		{
+			names: []string{"foo-1", "foo-2", "foo-3"},
+			exp:   podWithName("foo-3"),
+		},
+		{
+			names: []string{"foo-100", "foo-2", "foo-1"},
+			exp:   podWithName("foo-100"),
+		},
+		{
+			names: []string{"foo-100", "foo-120", "foo-30"},
+			exp:   podWithName("foo-120"),
+		},
+		{
+			names:  []string{"foo-100", "foo-2", "foo-baz"},
+			expErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		pods := make([]*corev1.Pod, len(test.names))
+		for i, name := range test.names {
+			pods[i] = podWithName(name)
+		}
+
+		pod, err := findPodToRemove(pods)
+		if test.expErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, test.exp, pod)
+		}
+	}
 }

--- a/pkg/m3admin/placement/options_test.go
+++ b/pkg/m3admin/placement/options_test.go
@@ -21,21 +21,34 @@
 package placement
 
 import (
-	"github.com/m3db/m3/src/query/generated/proto/admin"
-	"github.com/m3db/m3cluster/generated/proto/placementpb"
-	m3placement "github.com/m3db/m3cluster/placement"
+	"testing"
+
+	"github.com/m3db/m3db-operator/pkg/m3admin"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
-// Client provides the interface to interact with the placement API
-type Client interface {
-	// Init will initialize a placement give a valid placement request
-	Init(request *admin.PlacementInitRequest) error
-	// Get will provide the current placement
-	Get() (placement m3placement.Placement, err error)
-	// Delete will delete the current placment
-	Delete() error
-	// Add will add an instance to the placement
-	Add(instance placementpb.Instance) error
-	// Remove removes a given instance with the given ID from the placement.
-	Remove(id string) error
+func TestOptions(t *testing.T) {
+	client := &placementClient{}
+
+	opt := WithURL("...")
+	assert.Error(t, opt.execute(client))
+
+	const url = "http://localhost:1234"
+	l := zap.NewNop()
+	m3cl := m3admin.NewClient()
+	opts := []Option{
+		WithURL(url),
+		WithLogger(l),
+		WithClient(m3cl),
+	}
+
+	for _, opt := range opts {
+		assert.NoError(t, opt.execute(client))
+	}
+
+	assert.Equal(t, l, client.logger)
+	assert.Equal(t, m3cl, client.client)
+	assert.Equal(t, url, client.url)
 }

--- a/pkg/m3admin/placement/placement_mock.go
+++ b/pkg/m3admin/placement/placement_mock.go
@@ -105,3 +105,15 @@ func (m *MockClient) Add(instance placementpb.Instance) error {
 func (mr *MockClientMockRecorder) Add(instance interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockClient)(nil).Add), instance)
 }
+
+// Remove mocks base method
+func (m *MockClient) Remove(id string) error {
+	ret := m.ctrl.Call(m, "Remove", id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Remove indicates an expected call of Remove
+func (mr *MockClientMockRecorder) Remove(id interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockClient)(nil).Remove), id)
+}

--- a/pkg/m3admin/placement/placement_test.go
+++ b/pkg/m3admin/placement/placement_test.go
@@ -169,3 +169,19 @@ func TestGetErr(t *testing.T) {
 	require.Nil(t, placement)
 	require.Error(t, err)
 }
+
+func TestRemove(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.String() != "/api/v1/services/m3db/placement/instFoo" || r.Method != http.MethodDelete {
+			w.WriteHeader(404)
+			return
+		}
+		w.WriteHeader(200)
+		w.Write([]byte(`{"placement": {}}`))
+	}))
+	defer s.Close()
+
+	client := newPlacementClient(t, s.URL)
+	err := client.Remove("instFoo")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
- Support cluster instance removal w/ sanity checks.
- Implement remove operations in m3admin client.
- Define m3 placement URLs locally (remove URL has `{%s}` in it for mux
  var parsing, defining locally to "freeze" paths).