### PR TITLE
[tests] add e2e integration framework + tests

### DIFF
--- a/.excludecoverage
+++ b/.excludecoverage
@@ -3,3 +3,4 @@ vendor/
 _tools/
 zz_generated.deepcopy.go
 pkg/client/
+integration/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -983,6 +983,7 @@
     "go.uber.org/zap/zapcore",
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
+    "k8s.io/api/rbac/v1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake",

--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,19 @@ test: test-base
 	@echo "--- $@"
 	gocov convert $(coverfile) | gocov report
 
+kill-proxy:
+	kubectl proxy &
+	pkill -f 'kubectl proxy'
+
 .PHONY: test-e2e
 test-e2e:
 	@echo "--- $@"
+	@which kubectl > /dev/null || (echo "error: need kubectl installed" && exit 1)
+	kubectl delete ns m3db-e2e-test-1 || true
+	kubectl proxy &
+	go clean -testcache
 	go test -v -tags integration ./integration/e2e
+	pkill -f 'kubectl proxy'
 
 .PHONY: testhtml
 testhtml: test-base

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,11 @@ test: test-base
 	@echo "--- $@"
 	gocov convert $(coverfile) | gocov report
 
+.PHONY: test-e2e
+test-e2e:
+	@echo "--- $@"
+	go test -v -tags integration ./integration/e2e
+
 .PHONY: testhtml
 testhtml: test-base
 	@echo "--- $@"
@@ -120,7 +125,7 @@ mock-gen: install-ci-tools mock-gen-no-deps
 .PHONY: license-gen
 license-gen:
 	@echo "--- :apache: $@"
-	@find $(SELF_DIR)/pkg/$(SUBDIR) -name '*.go' | PATH=$(retool_bin_path):$(PATH) xargs -I{} update-license {}
+	@find $(SELF_DIR)/pkg/$(SUBDIR) $(SELF_DIR)/integration -name '*.go' | PATH=$(retool_bin_path):$(PATH) xargs -I{} update-license {}
 
 .PHONY: mock-gen-no-deps
 mock-gen-no-deps:

--- a/Makefile
+++ b/Makefile
@@ -63,19 +63,10 @@ test: test-base
 	@echo "--- $@"
 	gocov convert $(coverfile) | gocov report
 
-kill-proxy:
-	kubectl proxy &
-	pkill -f 'kubectl proxy'
-
 .PHONY: test-e2e
 test-e2e:
 	@echo "--- $@"
-	@which kubectl > /dev/null || (echo "error: need kubectl installed" && exit 1)
-	kubectl delete ns m3db-e2e-test-1 || true
-	kubectl proxy &
-	go clean -testcache
-	go test -v -tags integration ./integration/e2e
-	pkill -f 'kubectl proxy'
+	$(SELF_DIR)/scripts/run_e2e_tests.sh
 
 .PHONY: testhtml
 testhtml: test-base

--- a/integration/e2e/README.md
+++ b/integration/e2e/README.md
@@ -20,12 +20,12 @@ Scripts are included for creating clusters on GKE which would be safe to test ag
 
 ## Running the tests
 
-**NOTE** It is generally a good idea to run the tests with `GOCACHE=off`, otherwise running the tests with the same test
-code may cause cached tests to run.
+**NOTE** It is generally a good idea to run the tests a clean go test cache, otherwise running the tests with the same
+test code may cause cached tests to run. The make target accomplishes this by running `go clean -testcache` first.
 
 ```
 # With a working Kubernetes cluster and a correctly configured current kubectl context:
-$ go clean -testcache && make test-e2e
+$ make test-e2e
 --- test-e2e
 go test -v -tags integration ./integration/e2e
 2018-11-22T15:36:41.370-0500    INFO    setting up test suite

--- a/integration/e2e/README.md
+++ b/integration/e2e/README.md
@@ -20,8 +20,16 @@ Scripts are included for creating clusters on GKE which would be safe to test ag
 
 ## Running the tests
 
-**NOTE** It is generally a good idea to run the tests a clean go test cache, otherwise running the tests with the same
-test code may cause cached tests to run. The make target accomplishes this by running `go clean -testcache` first.
+**NOTE**: If you are running on a platform such as GKE you may need to grant your user the ability to create roles. From
+the [GKE
+docs](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#prerequisites_for_using_role-based_access_control):
+```
+kubectl create clusterrolebinding cluster-admin-binding \
+  --clusterrole cluster-admin --user $USER_ACCOUNT
+```
+
+It is generally a good idea to run the tests a clean go test cache, otherwise running the tests with the same test code
+may cause cached tests to run. The make target accomplishes this by running `go clean -testcache` first.
 
 ```
 # With a working Kubernetes cluster and a correctly configured current kubectl context:

--- a/integration/e2e/README.md
+++ b/integration/e2e/README.md
@@ -1,0 +1,34 @@
+# E2E Tests
+
+This directory contains the framework for testing the M3DB Operator against "real" Kubernetes clusters. It tests basic
+functionality as well as operator behavior under various failure scenarios.
+
+Design of this framework is influenced by CoreOS's excellent [etcd-operator](https://github.com/coreos/etcd-operator)
+and [prometheus-operator](https://github.com/coreos/prometheus-operator) e2e tests.
+
+## WARNING!
+
+This test framework will attempt to only make modifications to namespaces it creates which start with the prefix
+`m3db-e2e-test`. It will attempt to clean those namespaces up at the end of test runs.
+
+**HOWEVER**, to test failure scenarios the framework may have to modify resources outside of its namespaces (such as
+persistent volumes). For this reason, it is not recommended to run this test suite against production clusters. In the
+future we will add config parameters to not modify objects outside of our namespaces, but it is still not recommended to
+run these tests against production clusters.
+
+Scripts are included for creating clusters on GKE which would be safe to test against in isolation.
+
+## Running the tests
+
+**NOTE** It is generally a good idea to run the tests with `GOCACHE=off`, otherwise running the tests with the same test
+code may cause cached tests to run.
+
+```
+# With a working Kubernetes cluster and a correctly configured current kubectl context:
+$ go clean -testcache && make test-e2e
+--- test-e2e
+go test -v -tags integration ./integration/e2e
+2018-11-22T15:36:41.370-0500    INFO    setting up test suite
+2018-11-22T15:36:44.206-0500    INFO    creating namespace      {"namespace": "m3db-e2e-test-1"}
+...
+```

--- a/integration/e2e/basic_test.go
+++ b/integration/e2e/basic_test.go
@@ -1,0 +1,75 @@
+// +build integration
+
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3db-operator/integration/harness"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+const (
+	placementCheckInterval = 5 * time.Second
+	placementCheckTimeout  = 5 * time.Minute
+)
+
+func TestCreateCluster(t *testing.T) {
+	h := harness.Global
+
+	cluster, err := h.CreateM3DBCluster("cluster-1.yaml")
+	require.NoError(t, err)
+
+	cl, err := h.NewPlacementClient(cluster)
+	require.NoError(t, err)
+
+	err = wait.Poll(placementCheckInterval, placementCheckTimeout, func() (bool, error) {
+		pl, err := cl.Get()
+		if err != nil {
+			h.Logger.Warn("error fetching placement", zap.Error(err))
+			return false, nil
+		}
+
+		if pl.NumInstances() != 3 {
+			h.Logger.Info("waiting for 3 instances to exist")
+			return false, nil
+		}
+
+		for _, inst := range pl.Instances() {
+			if !inst.IsAvailable() {
+				h.Logger.Info("waiting for instance to be available", zap.String("instance", inst.ID()))
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+
+	assert.NoError(t, err)
+}

--- a/integration/e2e/dummy.go
+++ b/integration/e2e/dummy.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package e2e
+
+// This file merely exists to have a non-build constraint excluded go file in
+// the integration tests.

--- a/integration/e2e/main_test.go
+++ b/integration/e2e/main_test.go
@@ -1,0 +1,35 @@
+// +build integration
+
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package e2e
+
+import (
+	"testing"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	"github.com/m3db/m3db-operator/integration/harness"
+)
+
+func TestMain(m *testing.M) {
+	harness.RunSuite(m)
+}

--- a/integration/harness/dummy.go
+++ b/integration/harness/dummy.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package harness
+
+// This file merely exists to have a non-build constraint excluded go file in
+// the integration tests.

--- a/integration/harness/etcd.go
+++ b/integration/harness/etcd.go
@@ -1,0 +1,132 @@
+// +build integration
+
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package harness
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"go.uber.org/zap"
+)
+
+const (
+	etcdHealthInterval = 10 * time.Second
+	etcdHealthTimeout  = 5 * time.Minute
+)
+
+func (h *Harness) createEtcdCluster() error {
+	f, err := os.Open("../manifests/etcd.yaml")
+	if err != nil {
+		return err
+	}
+
+	reader := yaml.NewYAMLOrJSONDecoder(f, 2048)
+
+	headlessSvc := &corev1.Service{}
+	if err := reader.Decode(headlessSvc); err != nil {
+		return err
+	}
+
+	clusterSvc := &corev1.Service{}
+	if err := reader.Decode(clusterSvc); err != nil {
+		return err
+	}
+
+	statefulSet := &appsv1.StatefulSet{}
+	if err := reader.Decode(statefulSet); err != nil {
+		return err
+	}
+
+	for _, svc := range []*corev1.Service{
+		headlessSvc,
+		clusterSvc,
+	} {
+		h.Logger.Info("creating etcd service", zap.String("service", svc.Name))
+		if _, err := h.KubeClient.CoreV1().Services(h.Namespace).Create(svc); err != nil {
+			return err
+		}
+	}
+
+	h.Logger.Info("creating etcd statefulset", zap.String("statefulset", statefulSet.Name))
+	if _, err := h.KubeClient.AppsV1().StatefulSets(h.Namespace).Create(statefulSet); err != nil {
+		return err
+	}
+
+	if err := h.waitEtcdHealth(etcdHealthInterval, etcdHealthTimeout); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *Harness) waitEtcdHealth(interval, timeout time.Duration) error {
+	return wait.Poll(interval, timeout, wait.ConditionFunc(func() (bool, error) {
+		err := h.checkEtcdHealth()
+		if err != nil {
+			h.Logger.Error("error checking etcd health", zap.Error(err))
+			return false, nil
+		}
+		return true, nil
+	}))
+}
+
+func (h *Harness) checkEtcdHealth() error {
+	url := fmt.Sprintf(proxyBaseURLFmt, h.Namespace, "etcd-cluster", "2379") + "/health"
+
+	h.Logger.Info("checking etcd health", zap.String("url", url))
+
+	health := struct {
+		Health string `json:"health"`
+	}{}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		return err
+	}
+
+	if health.Health != "true" {
+		return errors.New("unhealthy response from cluster")
+	}
+
+	return nil
+}

--- a/integration/harness/harness.go
+++ b/integration/harness/harness.go
@@ -1,0 +1,171 @@
+// +build integration
+
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package harness
+
+import (
+	"fmt"
+
+	clientset "github.com/m3db/m3db-operator/pkg/client/clientset/versioned"
+
+	corev1 "k8s.io/api/core/v1"
+	extclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"go.uber.org/zap"
+)
+
+const (
+	defaultNamespace              = "m3db-e2e-test-1"
+	defaultClusterRoleName        = "operator-e2e-test"
+	defaultClusterRoleBindingName = defaultClusterRoleName
+	proxyBaseURLFmt               = "http://localhost:8001/api/v1/namespaces/%s/services/%s:%s/proxy"
+)
+
+// Global is the global read-only harness used by all tests.
+var Global *Harness
+
+// Harness encapsulates all dependencies to run a test.
+type Harness struct {
+	Logger     *zap.Logger
+	KubeClient kubernetes.Interface
+	CRDClient  clientset.Interface
+	ExtClient  extclient.Interface
+	Namespace  string
+	Flags      Flags
+}
+
+type suiteOpts struct {
+	flags  Flags
+	logger *zap.Logger
+}
+
+func buildSuite(opts *suiteOpts) (*Harness, error) {
+	cfg, err := clientcmd.BuildConfigFromFlags("", opts.flags.KubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	crdClient, err := clientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	extClient, err := extclient.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	h := &Harness{
+		Logger:     opts.logger,
+		KubeClient: kubeClient,
+		CRDClient:  crdClient,
+		ExtClient:  extClient,
+		Namespace:  defaultNamespace,
+		Flags:      opts.flags,
+	}
+
+	return h, nil
+}
+
+func (h *Harness) ensureNamespace() error {
+	ns, err := h.KubeClient.CoreV1().Namespaces().Get(h.Namespace, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return h.createNamespace(defaultNamespace)
+		}
+		return err
+	}
+
+	if ns.Status.Phase != corev1.NamespaceActive {
+		return fmt.Errorf("namespace %s is in phase != Active (%s)", h.Namespace, ns.Status.Phase)
+	}
+
+	h.Logger.Info("found namespace", zap.String("namespace", ns.Name))
+	return nil
+}
+
+func (h *Harness) setupSuite() error {
+	if err := h.ensureNamespace(); err != nil {
+		return err
+	}
+
+	if err := h.installOperator(); err != nil {
+		return err
+	}
+
+	if err := h.createEtcdCluster(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *Harness) createNamespace(ns string) error {
+	if h.Flags.SkipCreateNamespace {
+		return nil
+	}
+
+	h.Logger.Info("creating namespace", zap.String("namespace", ns))
+	_, err := h.KubeClient.Core().Namespaces().Create(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ns,
+		},
+	})
+	return err
+}
+
+func (h *Harness) teardownSuite() error {
+	if !h.Flags.SkipDeleteRBAC {
+		h.Logger.Info("deleting clusterrole", zap.String("clusterrole", defaultClusterRoleName))
+		err := h.KubeClient.RbacV1().ClusterRoles().Delete(defaultClusterRoleName, nil)
+		if err != nil {
+			return err
+		}
+
+		h.Logger.Info("deleting clusterrolebinding", zap.String("clusterrolebinding", defaultClusterRoleBindingName))
+		err = h.KubeClient.RbacV1().ClusterRoleBindings().Delete(defaultClusterRoleBindingName, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	if h.Flags.SkipDeleteNamespace {
+		return nil
+	}
+
+	h.Logger.Info("deleting namespace")
+	err := h.KubeClient.CoreV1().Namespaces().Delete(h.Namespace, nil)
+	if err != nil {
+		return err
+	}
+	h.Logger.Info("namespace deleted")
+	return nil
+}

--- a/integration/harness/m3admin.go
+++ b/integration/harness/m3admin.go
@@ -1,0 +1,49 @@
+// +build integration
+
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package harness
+
+import (
+	"fmt"
+
+	myspec "github.com/m3db/m3db-operator/pkg/apis/m3dboperator/v1"
+	"github.com/m3db/m3db-operator/pkg/k8sops"
+	"github.com/m3db/m3db-operator/pkg/m3admin/placement"
+)
+
+// NewPlacementClient constructs an m3admin placement client for the tests.
+func (h *Harness) NewPlacementClient(cluster *myspec.M3DBCluster) (placement.Client, error) {
+	svc, err := k8sops.GenerateCoordinatorService(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf(proxyBaseURLFmt, h.Namespace, svc.Name, "7201")
+	cl, err := placement.NewClient(
+		placement.WithURL(url),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return cl, nil
+}

--- a/integration/harness/m3dbcluster.go
+++ b/integration/harness/m3dbcluster.go
@@ -1,0 +1,73 @@
+// +build integration
+
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package harness
+
+import (
+	"os"
+	"path/filepath"
+
+	myspec "github.com/m3db/m3db-operator/pkg/apis/m3dboperator/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"go.uber.org/zap"
+)
+
+// CreateM3DBCluster creates an m3db cluster from a predefined manifest.
+func (h *Harness) CreateM3DBCluster(filename string) (*myspec.M3DBCluster, error) {
+	path := filepath.Join("../manifests", filename)
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := yaml.NewYAMLOrJSONDecoder(f, 2048)
+
+	cm := &corev1.ConfigMap{}
+	cluster := &myspec.M3DBCluster{}
+
+	for _, iface := range []interface{}{
+		cm,
+		cluster,
+	} {
+
+		if err := reader.Decode(iface); err != nil {
+			return nil, err
+		}
+	}
+
+	h.Logger.Info("creating configmap", zap.String("configmap", cm.Name))
+	if _, err := h.KubeClient.CoreV1().ConfigMaps(h.Namespace).Create(cm); err != nil {
+		return nil, err
+	}
+
+	h.Logger.Info("creating m3dbcluster", zap.String("m3dbcluster", cluster.Name))
+	cluster, err = h.CRDClient.OperatorV1().M3DBClusters(h.Namespace).Create(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	return cluster, nil
+}

--- a/integration/harness/operator.go
+++ b/integration/harness/operator.go
@@ -1,0 +1,89 @@
+// +build integration
+
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package harness
+
+import (
+	"os"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"go.uber.org/zap"
+)
+
+func (h *Harness) installOperator() error {
+	f, err := os.Open("../manifests/operator.yaml")
+	if err != nil {
+		return err
+	}
+
+	reader := yaml.NewYAMLOrJSONDecoder(f, 2048)
+
+	sa := &corev1.ServiceAccount{}
+	role := &rbacv1.ClusterRole{}
+	rb := &rbacv1.ClusterRoleBinding{}
+	sts := &appsv1.StatefulSet{}
+
+	for _, iface := range []interface{}{
+		sa,
+		role,
+		rb,
+		sts,
+	} {
+		if err := reader.Decode(iface); err != nil {
+			return err
+		}
+	}
+
+	h.Logger.Info("creating serviceaccount", zap.String("serviceaccount", sa.Name))
+	if _, err := h.KubeClient.CoreV1().ServiceAccounts(h.Namespace).Create(sa); err != nil {
+		return err
+	}
+
+	rc := h.KubeClient.RbacV1()
+
+	if !h.Flags.SkipCreateRBAC {
+		h.Logger.Info("creating clusterrole", zap.String("role", role.Name))
+		if _, err := rc.ClusterRoles().Create(role); err != nil {
+			if err != nil && !errors.IsAlreadyExists(err) {
+				return err
+			}
+			h.Logger.Info("found existing clusterrole")
+		}
+
+		h.Logger.Info("creating rolebinding", zap.String("rolebinding", rb.Name))
+		if _, err := rc.ClusterRoleBindings().Create(rb); err != nil {
+			if err != nil && !errors.IsAlreadyExists(err) {
+				return err
+			}
+			h.Logger.Info("found existing clusterrolebinding")
+		}
+	}
+
+	h.Logger.Info("creating statefulset", zap.String("statefulset", sts.Name))
+	_, err = h.KubeClient.AppsV1().StatefulSets(h.Namespace).Create(sts)
+	return err
+}

--- a/integration/harness/operator.go
+++ b/integration/harness/operator.go
@@ -60,7 +60,10 @@ func (h *Harness) installOperator() error {
 
 	h.Logger.Info("creating serviceaccount", zap.String("serviceaccount", sa.Name))
 	if _, err := h.KubeClient.CoreV1().ServiceAccounts(h.Namespace).Create(sa); err != nil {
-		return err
+		if !errors.IsAlreadyExists(err) {
+			return err
+		}
+		h.Logger.Info("found existing serviceaccount")
 	}
 
 	rc := h.KubeClient.RbacV1()
@@ -68,7 +71,7 @@ func (h *Harness) installOperator() error {
 	if !h.Flags.SkipCreateRBAC {
 		h.Logger.Info("creating clusterrole", zap.String("role", role.Name))
 		if _, err := rc.ClusterRoles().Create(role); err != nil {
-			if err != nil && !errors.IsAlreadyExists(err) {
+			if !errors.IsAlreadyExists(err) {
 				return err
 			}
 			h.Logger.Info("found existing clusterrole")
@@ -76,7 +79,7 @@ func (h *Harness) installOperator() error {
 
 		h.Logger.Info("creating rolebinding", zap.String("rolebinding", rb.Name))
 		if _, err := rc.ClusterRoleBindings().Create(rb); err != nil {
-			if err != nil && !errors.IsAlreadyExists(err) {
+			if !errors.IsAlreadyExists(err) {
 				return err
 			}
 			h.Logger.Info("found existing clusterrolebinding")

--- a/integration/harness/run_suite.go
+++ b/integration/harness/run_suite.go
@@ -1,0 +1,116 @@
+// +build integration
+
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package harness
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func exitErr() {
+	os.Exit(1)
+}
+
+func buildLogger(flags *Flags) *zap.Logger {
+	cfg := zap.NewDevelopmentConfig()
+	cfg.DisableCaller = true
+	cfg.DisableStacktrace = true
+	cfg.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
+
+	logger, err := cfg.Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error building logger: %v", err)
+		exitErr()
+	}
+
+	return logger
+}
+
+func homeKubeConfig() string {
+	home := os.Getenv("HOME")
+	if home == "" {
+		fmt.Fprintf(os.Stderr, "$HOME cannot be empty if not setting kubeconfig path")
+		exitErr()
+	}
+
+	return filepath.Join(home, ".kube", "config")
+}
+
+// Flags define parameters for the test.
+type Flags struct {
+	KubeConfig          string
+	Verbose             bool
+	SkipCreateNamespace bool
+	SkipDeleteNamespace bool
+	SkipCreateRBAC      bool
+	SkipDeleteRBAC      bool
+}
+
+// RunSuite runs the test suite.
+func RunSuite(m *testing.M) {
+	flags := Flags{}
+	flag.StringVar(&flags.KubeConfig, "kubeconfig", "", "Path to kubeconfig (default $HOME/.kube/config)")
+	flag.BoolVar(&flags.Verbose, "debug", false, "enable debug logging")
+	flag.BoolVar(&flags.SkipCreateNamespace, "skip-create-ns", false, "skip namespace creation")
+	flag.BoolVar(&flags.SkipDeleteNamespace, "skip-delete-ns", false, "skip namespace deletion")
+	flag.BoolVar(&flags.SkipCreateRBAC, "skip-create-rbac", false, "skip RBAC resource creation")
+	flag.BoolVar(&flags.SkipDeleteRBAC, "skip-delete-rbac", false, "skip RBAC resource deletion")
+	flag.Parse()
+
+	if flags.KubeConfig == "" {
+		flags.KubeConfig = homeKubeConfig()
+	}
+
+	logger := buildLogger(nil)
+	logger.Info("setting up test suite")
+
+	opts := &suiteOpts{
+		flags:  flags,
+		logger: logger,
+	}
+
+	harness, err := buildSuite(opts)
+	if err != nil {
+		logger.Fatal("error building suite", zap.Error(err))
+	}
+
+	if err := harness.setupSuite(); err != nil {
+		logger.Fatal("error setting up suite", zap.Error(err))
+	}
+
+	Global = harness
+
+	code := m.Run()
+
+	if err := harness.teardownSuite(); err != nil {
+		logger.Fatal("error tearing down suite")
+	}
+
+	os.Exit(code)
+}

--- a/integration/manifests/cluster-1.yaml
+++ b/integration/manifests/cluster-1.yaml
@@ -1,0 +1,235 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: m3-configuration
+data:
+  m3.yml: |+
+    coordinator:
+      listenAddress:
+        type: "config"
+        value: "0.0.0.0:7201"
+      metrics:
+        scope:
+          prefix: "coordinator"
+        prometheus:
+          handlerPath: /metrics
+          listenAddress: 0.0.0.0:7203
+        sanitization: prometheus
+        samplingRate: 1.0
+        extended: none
+
+    db:
+      logging:
+        level: info
+
+      metrics:
+        prometheus:
+          handlerPath: /metrics
+        sanitization: prometheus
+        samplingRate: 1.0
+        extended: detailed
+
+      listenAddress: 0.0.0.0:9000
+      clusterListenAddress: 0.0.0.0:9001
+      httpNodeListenAddress: 0.0.0.0:9002
+      httpClusterListenAddress: 0.0.0.0:9003
+      debugListenAddress: 0.0.0.0:9004
+
+      hostID:
+        resolver: hostname
+
+      client:
+        writeConsistencyLevel: majority
+        readConsistencyLevel: unstrict_majority
+        writeTimeout: 10s
+        fetchTimeout: 15s
+        connectTimeout: 20s
+        writeRetry:
+            initialBackoff: 500ms
+            backoffFactor: 3
+            maxRetries: 2
+            jitter: true
+        fetchRetry:
+            initialBackoff: 500ms
+            backoffFactor: 2
+            maxRetries: 3
+            jitter: true
+        backgroundHealthCheckFailLimit: 4
+        backgroundHealthCheckFailThrottleFactor: 0.5
+
+      gcPercentage: 100
+
+      writeNewSeriesAsync: true
+      writeNewSeriesLimitPerSecond: 1048576
+      writeNewSeriesBackoffDuration: 2ms
+
+      bootstrap:
+        bootstrappers:
+            - filesystem
+            - commitlog
+            - peers
+            - uninitialized_topology
+        fs:
+            numProcessorsPerCPU: 0.125
+
+      commitlog:
+        flushMaxBytes: 524288
+        flushEvery: 1s
+        queue:
+            calculationType: fixed
+            size: 2097152
+        blockSize: 10m
+
+      fs:
+        filePathPrefix: /var/lib/m3db
+        writeBufferSize: 65536
+        dataReadBufferSize: 65536
+        infoReadBufferSize: 128
+        seekReadBufferSize: 4096
+        throughputLimitMbps: 100.0
+        throughputCheckEvery: 128
+
+      repair:
+        enabled: false
+        interval: 2h
+        offset: 30m
+        jitter: 1h
+        throttle: 2m
+        checkInterval: 1m
+
+      pooling:
+        blockAllocSize: 16
+        type: simple
+        seriesPool:
+            size: 262144
+            lowWatermark: 0.7
+            highWatermark: 1.0
+        blockPool:
+            size: 262144
+            lowWatermark: 0.7
+            highWatermark: 1.0
+        encoderPool:
+            size: 262144
+            lowWatermark: 0.7
+            highWatermark: 1.0
+        closersPool:
+            size: 104857
+            lowWatermark: 0.7
+            highWatermark: 1.0
+        contextPool:
+            size: 262144
+            lowWatermark: 0.7
+            highWatermark: 1.0
+        segmentReaderPool:
+            size: 16384
+            lowWatermark: 0.7
+            highWatermark: 1.0
+        iteratorPool:
+            size: 2048
+            lowWatermark: 0.7
+            highWatermark: 1.0
+        fetchBlockMetadataResultsPool:
+            size: 65536
+            capacity: 32
+            lowWatermark: 0.7
+            highWatermark: 1.0
+        fetchBlocksMetadataResultsPool:
+            size: 32
+            capacity: 4096
+            lowWatermark: 0.7
+            highWatermark: 1.0
+        hostBlockMetadataSlicePool:
+            size: 131072
+            capacity: 3
+            lowWatermark: 0.7
+            highWatermark: 1.0
+        blockMetadataPool:
+            size: 65536
+            lowWatermark: 0.7
+            highWatermark: 1.0
+        blockMetadataSlicePool:
+            size: 65536
+            capacity: 32
+            lowWatermark: 0.7
+            highWatermark: 1.0
+        blocksMetadataPool:
+            size: 65536
+            lowWatermark: 0.7
+            highWatermark: 1.0
+        blocksMetadataSlicePool:
+            size: 32
+            capacity: 4096
+            lowWatermark: 0.7
+            highWatermark: 1.0
+        identifierPool:
+            size: 262144
+            lowWatermark: 0.7
+            highWatermark: 1.0
+        bytesPool:
+            buckets:
+                - capacity: 16
+                  size: 524288
+                  lowWatermark: 0.7
+                  highWatermark: 1.0
+                - capacity: 32
+                  size: 262144
+                  lowWatermark: 0.7
+                  highWatermark: 1.0
+                - capacity: 64
+                  size: 131072
+                  lowWatermark: 0.7
+                  highWatermark: 1.0
+                - capacity: 128
+                  size: 65536
+                  lowWatermark: 0.7
+                  highWatermark: 1.0
+                - capacity: 256
+                  size: 65536
+                  lowWatermark: 0.7
+                  highWatermark: 1.0
+                - capacity: 1440
+                  size: 16384
+                  lowWatermark: 0.7
+                  highWatermark: 1.0
+                - capacity: 4096
+                  size: 8192
+                  lowWatermark: 0.7
+                  highWatermark: 1.0
+      config:
+        service:
+            env: default_env
+            zone: embedded
+            service: m3db
+            cacheDir: /var/lib/m3kv
+            etcdClusters:
+            - zone: embedded
+              endpoints:
+              - http://etcd-0.etcd:2379
+              - http://etcd-1.etcd:2379
+              - http://etcd-2.etcd:2379
+---
+apiVersion: operator.m3db.io/v1
+kind: M3DBCluster
+metadata:
+  name: m3db-cluster-test-1
+spec:
+  image: quay.io/m3/m3dbnode:latest
+  replicationFactor: 3
+  numberOfShards: 256
+  isolationGroups:
+    - name: us-east1-b
+      numInstances: 1
+    - name: us-east1-c
+      numInstances: 1
+    - name: us-east1-d
+      numInstances: 1
+  namespaces:
+    - name: metrics-10s:2d
+      preset: 10s:2d
+  resources:
+    requests:
+      memory: 4Gi
+      cpu: '1'
+    limits:
+      memory: 12Gi
+      cpu: '4'

--- a/integration/manifests/etcd.yaml
+++ b/integration/manifests/etcd.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd
+  labels:
+    app: etcd
+spec:
+  ports:
+  - port: 2379
+    name: client
+  - port: 2380
+    name: peer
+  clusterIP: None
+  selector:
+    app: etcd
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-cluster
+  labels:
+    app: etcd
+spec:
+  selector:
+    app: etcd
+  ports:
+  - port: 2379
+    protocol: TCP
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: etcd
+  labels:
+    app: etcd
+spec:
+  serviceName: "etcd"
+  replicas: 3
+  selector:
+    matchLabels:
+      app: etcd
+  template:
+    metadata:
+      labels:
+        app: etcd
+    spec:
+      containers:
+      - name: etcd
+        image: quay.io/coreos/etcd:v3.3.3
+        imagePullPolicy: Always
+        command:
+        - "etcd"
+        - "--name"
+        - "$(MY_POD_NAME)"
+        - "--listen-peer-urls"
+        - "http://$(MY_IP):2380"
+        - "--listen-client-urls"
+        - "http://$(MY_IP):2379,http://127.0.0.1:2379"
+        - "--advertise-client-urls"
+        - "http://$(MY_POD_NAME).etcd:2379"
+        - "--initial-cluster-token"
+        - "etcd-cluster-1"
+        - "--initial-advertise-peer-urls"
+        - "http://$(MY_POD_NAME).etcd:2380"
+        - "--initial-cluster"
+        - "etcd-0=http://etcd-0.etcd:2380,etcd-1=http://etcd-1.etcd:2380,etcd-2=http://etcd-2.etcd:2380"
+        - "--initial-cluster-state"
+        - "new"
+        - "--data-dir"
+        - "/var/lib/etcd"
+        ports:
+        - containerPort: 2379
+          name: client
+        - containerPort: 2380
+          name: peer
+        env:
+        - name: MY_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/integration/manifests/operator.yaml
+++ b/integration/manifests/operator.yaml
@@ -1,7 +1,13 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: operator-test-sa
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.operator.name }}
+  name: operator-e2e-test
 rules:
 - apiGroups: ["extensions"]
   resources: ["deployments", "replicasets", "daemonsets"]
@@ -30,3 +36,39 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: operator-e2e-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operator-e2e-test
+subjects:
+- kind: ServiceAccount
+  name: operator-test-sa
+  namespace: m3db-e2e-test-1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: m3db-operator
+spec:
+  serviceName: m3db-operator
+  replicas: 1
+  selector:
+    matchLabels:
+      name: m3db-operator
+  template:
+    metadata:
+      labels:
+        name: m3db-operator
+    spec:
+      containers:
+        - name: m3db-operator
+          image: quay.io/m3db/m3db-operator:latest
+          command:
+          - m3db-operator
+          imagePullPolicy: Always
+      serviceAccount: operator-test-sa

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -ex
+
+function main() {
+  readonly NAMESPACE="m3db-e2e-test-1"
+
+  command -v kubectl > /dev/null || (echo "error: need kubectl installed" && exit 1)
+
+  # Check that we can reasonably connect to a cluster
+  kubectl cluster-info > /dev/null || (echo "unable to fetch cluster info" && exit 1)
+
+  # Delete the namespace in the case it exists
+  kubectl delete namespace $NAMESPACE 2> /dev/null || true
+
+  # Wait until it's gone
+  local NSCOUNT=0
+  while [[ $NSCOUNT -lt 10 ]]; do
+    if kubectl get namespace $NAMESPACE 2>&1 | grep -q "not found"; then
+      break
+    else
+      echo "waiting for namespace to be deleted"
+      sleep 5
+      ((NSCOUNT++))
+    fi
+  done
+
+  # If a kubectl proxy process is running, delete and wait until it's dead
+  if pgrep -fq 'kubectl proxy'; then
+    pkill -f 'kubectl proxy'
+    local PROXYCOUNT=0
+    while [[ $PROXYCOUNT -lt 10 ]]; do
+      if pgrep -fq 'kubectl proxy'; then
+        echo "waiting for proxy proccess to die"
+        sleep 5
+        ((PROXYCOUNT++))
+      else
+        break
+      fi
+    done
+  fi
+
+  kubectl proxy &
+  go clean -testcache
+  go test -v -tags integration ./integration/e2e
+  pkill -f "kubectl proxy"
+}
+
+main


### PR DESCRIPTION
This adds a basic integration test for ensuring operator functionality
against a real Kubernetes cluster.

So far only basic functionality is tested: installing the operator and
creating a 3 node M3DB cluster with no persistent storage. The tests
ensure the cluster is created within a certain amount of time and that
the placement is valid.

Note that these tests currently do not run on CI, but such functionality
is planned. Eventually we'll have creds and infrastructure to create a
GKE cluster from CI on certain commits. Right now the tests have to be
run locally against a working Kubernetes cluster.