### PR TITLE
[api] support Kubernetes 1.11

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:c1c3d6b976bf8a04d745f8f5003156ddce4f3965851939ff5d84304c85161c46"
+  digest = "1:a639b30711f62030ade1432a6bcf135c23c38607d1478d3ce53829ea2a664197"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
   pruneopts = ""
-  revision = "1fd54cf41e6e0e178ffe3c52b0e2260281f603e3"
-  version = "v0.32.0"
+  revision = "0ebda48a7f143b1cce9eb37a8c1106ac762a3430"
+  version = "v0.34.0"
 
 [[projects]]
   digest = "1:8e47871087b94913898333f37af26732faaab30cdb41571136cf7aec9921dae7"
@@ -117,7 +117,7 @@
   version = "v0.17.2"
 
 [[projects]]
-  digest = "1:6e73003ecd35f4487a5e88270d3ca0a81bc80dc88053ac7e4dcfec5fba30d918"
+  digest = "1:527e1e468c5586ef2645d143e9f5fbd50b4fe5abc8b1e25d9f1c416d22d24895"
   name = "github.com/gogo/protobuf"
   packages = [
     "jsonpb",
@@ -126,8 +126,8 @@
     "types",
   ]
   pruneopts = ""
-  revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
-  version = "v1.1.1"
+  revision = "4cbf7e384e768b4e01799441fdf2a706a5635ae7"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -146,7 +146,7 @@
   revision = "c65c006176ff7ff98bb916961c7abbc6b0afc0aa"
 
 [[projects]]
-  digest = "1:73a7106c799f98af4f3da7552906efc6a2570329f4cd2d2f5fb8f9d6c053ff2f"
+  digest = "1:530233672f656641b365f8efb38ed9fba80e420baff2ce87633813ab3755ed6d"
   name = "github.com/golang/mock"
   packages = [
     "gomock",
@@ -154,8 +154,8 @@
     "mockgen/model",
   ]
   pruneopts = ""
-  revision = "c34cdb4725f4c3844d095133c6e40e448b86589b"
-  version = "v1.1.1"
+  revision = "51421b967af1f557f93a59e0057aaf15ca02e29c"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
@@ -170,6 +170,14 @@
   pruneopts = ""
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:1e5b1e14524ed08301977b7b8e10c719ed853cbf3f24ecb66fae783a46f207a6"
+  name = "github.com/google/btree"
+  packages = ["."]
+  pruneopts = ""
+  revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
   branch = "master"
@@ -192,6 +200,17 @@
   version = "v0.2.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:5e345eb75d8bfb2b91cfbfe02a82a79c0b2ea55cf06c5a4d180a9321f36973b4"
+  name = "github.com/gregjones/httpcache"
+  packages = [
+    ".",
+    "diskcache",
+  ]
+  pruneopts = ""
+  revision = "c63ab54fda8f77302f8d414e19933f2b6026a089"
+
+[[projects]]
   digest = "1:05334858a0cfb538622a066e065287f63f42bee26a7fda93a789674225057201"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
@@ -200,12 +219,12 @@
   version = "v0.5.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:16503ad296459b0e65fbe60a5f41c097bd325c3f981fd26a5397bb0edbe3e31c"
+  digest = "1:62327a30877f944b5fd23d130487731a3004b319ff1864daa677d7e554898cc1"
   name = "github.com/hashicorp/go-retryablehttp"
   packages = ["."]
   pruneopts = ""
-  revision = "e651d75abec6fbd4f2c09508f72ae7af8a8b7171"
+  revision = "4502c0ecdaf0b50d857611af23831260f99be6bf"
+  version = "v0.5.0"
 
 [[projects]]
   digest = "1:3313a63031ae281e5f6fd7b0bbca733dfa04d2429df86519e3b4d4c016ccb836"
@@ -217,14 +236,6 @@
   pruneopts = ""
   revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
   version = "v0.5.0"
-
-[[projects]]
-  branch = "master"
-  digest = "1:f81c8d7354cc0c6340f2f7a48724ee6c2b3db3e918ecd441c985b4d2d97dd3e7"
-  name = "github.com/howeyc/gopass"
-  packages = ["."]
-  pruneopts = ""
-  revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
 
 [[projects]]
   digest = "1:7ab38c15bd21e056e3115c8b526d201eaf74e0308da9370997c6b3c187115d36"
@@ -244,11 +255,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1aa5e3a611782785b985a64a27254bf93e9a23b24a5b9f3c4dfc49fb6e07fa39"
+  digest = "1:bea542e853f98bfcc80ecbe8fe0f32bc52c97664102aacdd7dca676354ef2faa"
   name = "github.com/kubernetes/utils"
   packages = ["pointer"]
   pruneopts = ""
-  revision = "1bd4f387aa67de2eec07a362c10bc8bd7fe74237"
+  revision = "0d26856f57b32ec3398579285e5c8a2bfe8c5243"
 
 [[projects]]
   digest = "1:01cff63b697cafaf65ced3d20061e96bec17df13e45228e79cf430c6a3484ee1"
@@ -267,7 +278,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c2484f70243efc7517df00523731b810b07981910797e9111b681e5238e671e1"
+  digest = "1:ecb35120cb727ffc6969e8f86de4e525f0c7618dfc768a1ef5b6bfff13ca1605"
   name = "github.com/m3db/m3"
   packages = [
     "src/cluster/generated/proto/placementpb",
@@ -280,11 +291,11 @@
     "src/query/generated/proto/admin",
   ]
   pruneopts = ""
-  revision = "8fa049d7aacb77dfa286ecae41a9db90bdf6ba4d"
+  revision = "1654b7d24d116a6a8db14fc0772e55a6a3d21dda"
 
 [[projects]]
   branch = "master"
-  digest = "1:b797610f97780b8a3209f49b72e840b8213ee024fafd24f131542757cd89e4bd"
+  digest = "1:c629dd577574dca9f0fb45f3eb84ef2cbc23390481cef3159afb360f1362d335"
   name = "github.com/m3db/m3x"
   packages = [
     "clock",
@@ -295,7 +306,7 @@
     "watch",
   ]
   pruneopts = ""
-  revision = "4f657299af578e9aa28c557075c7307d4b756378"
+  revision = "05f4139118af43282373b5de26a693be4c910148"
 
 [[projects]]
   digest = "1:4142d94383572e74b42352273652c62afec5b23f325222ed09198f46009022d1"
@@ -363,6 +374,22 @@
   version = "1.0.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:c24598ffeadd2762552269271b3b1510df2d83ee6696c1e543a0ff653af494bc"
+  name = "github.com/petar/GoLLRB"
+  packages = ["llrb"]
+  pruneopts = ""
+  revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
+
+[[projects]]
+  digest = "1:b46305723171710475f2dd37547edd57b67b9de9f2a6267cafdd98331fd6897f"
+  name = "github.com/peterbourgon/diskv"
+  packages = ["."]
+  pruneopts = ""
+  revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
+  version = "v2.0.1"
+
+[[projects]]
   digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
@@ -371,15 +398,15 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:8b2082f564fe20dbb43a621ee0d57ae2777656ab14111d100d3d92d1b5b958b9"
+  digest = "1:6f218995d6a74636cfcab45ce03005371e682b4b9bee0e5eb0ccfd83ef85364f"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
     "prometheus/internal",
   ]
   pruneopts = ""
-  revision = "abad2d1bd44235a26707c172eab6bca5bf2dbad3"
-  version = "v0.9.1"
+  revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
+  version = "v0.9.2"
 
 [[projects]]
   branch = "master"
@@ -391,7 +418,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d522feb599bd02a4b76d3ad20b91668c87028a6b5fd19a1bed994e26f6cd3c6d"
+  digest = "1:3015ace839b82abfb015b6fc2aebf32f4a6a8c522defacd916552387948c22a8"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -399,11 +426,11 @@
     "model",
   ]
   pruneopts = ""
-  revision = "41aa239b4cce3c56ab88fc366ae8b0a6423fa239"
+  revision = "4724e9255275ce38f7179b2478abeae4e28c904f"
 
 [[projects]]
   branch = "master"
-  digest = "1:1f62ed2c173c42c1edad2e94e127318ea11b0d28c62590c82a8d2d3cde189afe"
+  digest = "1:2a434946be9f2f5498b2405a8607768aab439237ea13deff2edc59d9a44f8891"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
@@ -412,7 +439,7 @@
     "xfs",
   ]
   pruneopts = ""
-  revision = "185b4288413d2a0dd0806f78c90dde719829e5ae"
+  revision = "1dc9a6cbc91aacc3e8b2d63db4d2e957a5394ac4"
 
 [[projects]]
   digest = "1:2ba054ffd0e1bd13f2e6fa0b2203df5d9f04ff354f71bbb08168926c6b74b756"
@@ -498,15 +525,15 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f7be435e0ca22e2cd62b2d2542081a231685837170a87a3662abb7cdf9f3f1cd"
+  digest = "1:887074c37fcefc2f49b5ae9c6f9f36107341aec23185613d0e9f1ee81db7f94a"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   pruneopts = ""
-  revision = "3d3f9f413869b949e48070b5bc593aa22cc2b8f2"
+  revision = "505ab145d0a99da450461ae2c1a9f6cd10d1f447"
 
 [[projects]]
   branch = "master"
-  digest = "1:fbc2896199a45d32325e24ceb56624c7db49f9cfb068f739ee53339a8fb183b3"
+  digest = "1:6728b48c3404cbbebd73186cb2de79bf03395e8c3a8e5fe2079367f2c3fa85b0"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -517,11 +544,11 @@
     "idna",
   ]
   pruneopts = ""
-  revision = "88d92db4c548972d942ac2a3531a8a9a34c82ca6"
+  revision = "610586996380ceef02dd726cc09df7e00a3f8e56"
 
 [[projects]]
   branch = "master"
-  digest = "1:51d339a1d79f5c617fba14414aefb7dfd184b8ba0ddbb9f95251430b67c8aab8"
+  digest = "1:ea010cdb976f9de0c763728a76278f9109fca3299abd0dc3e8f2ccb9ff347268"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -531,18 +558,18 @@
     "jwt",
   ]
   pruneopts = ""
-  revision = "f42d05182288abf10faef86d16c0d07b8d40ea2d"
+  revision = "d668ce993890a79bda886613ee587a69dd5da7a6"
 
 [[projects]]
   branch = "master"
-  digest = "1:3f5c191d90f1cf365ff1f88e4b08eb766ee6ade1cb2e4efd7c316cf7e015ac17"
+  digest = "1:a89bd9b57bfccfbf42a9449a1fc2c94bd9d0e611762d074fdea2f4b9236c9ec0"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = ""
-  revision = "66b7b1311ac80bbafcd2daeef9a5e6e2cd1e2399"
+  revision = "7da8ea5c81829e397bdf930c5d8ba4b703616f33"
 
 [[projects]]
   digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
@@ -578,7 +605,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2ffbc49f24009cefaf06ecc67681a6e27a3d88a18d93ac5a0f5e0468c868865b"
+  digest = "1:7e195a06f97d56c21b838e35ca0e391940afbce38e5977f89abe0e2520d75848"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
@@ -587,7 +614,7 @@
     "internal/gopathwalk",
   ]
   pruneopts = ""
-  revision = "ea84011da2848032433bb8841abc1a9e5d5e2bb0"
+  revision = "2b6afc6596c9e42f2e06cfe83f76d0838f6f7263"
 
 [[projects]]
   digest = "1:77d3cff3a451d50be4b52db9c7766c0d8570ba47593f0c9dc72173adb208e788"
@@ -617,16 +644,16 @@
   version = "v0.9.1"
 
 [[projects]]
-  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
+  digest = "1:cedccf16b71e86db87a24f8d4c70b0a855872eb967cb906a66b95de56aefbd0d"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = ""
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
 
 [[projects]]
-  branch = "release-1.10"
-  digest = "1:e0709dedfcab806ae3f6d1b8acaaa60a1ac4487c5fd8154f454490eb54bbf35e"
+  branch = "release-1.11"
+  digest = "1:0a64a62b398949a3a2d9bfe58abea92aa826f80a8f6c2e3f8b33945425ebcd42"
   name = "k8s.io/api"
   packages = [
     "admissionregistration/v1alpha1",
@@ -653,17 +680,18 @@
     "rbac/v1alpha1",
     "rbac/v1beta1",
     "scheduling/v1alpha1",
+    "scheduling/v1beta1",
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
     "storage/v1beta1",
   ]
   pruneopts = ""
-  revision = "12444147eb1150aa5c80d2aae532cbc5b7be73d0"
+  revision = "2dd39edadc55ab8a4ab2b27b84a9ed1b467ef47e"
 
 [[projects]]
-  branch = "release-1.10"
-  digest = "1:d39affe538df2794e0c89aa14116da22faa3468ddf76bb1ad40f4bed04dffbd7"
+  branch = "release-1.11"
+  digest = "1:9affbbf1de50794b4724fe97256f4a290e1c9367807acc2b371a242e88d08074"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
@@ -675,11 +703,11 @@
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake",
   ]
   pruneopts = ""
-  revision = "f584b16eb23bd2a3fd292a027d698d95db427c5d"
+  revision = "e419c5771cdcec16d68b632a451dab1d383168a8"
 
 [[projects]]
-  branch = "release-1.10"
-  digest = "1:33bcc98ed218289d68aeac0799649844075ee7a2fb1e686040b605b5b5a1523c"
+  branch = "release-1.11"
+  digest = "1:2b9b504b5776d0c9dd2578d35e1e6eb8868fe8926461d0b7533a5a82a618551a"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -725,11 +753,11 @@
     "third_party/forked/golang/reflect",
   ]
   pruneopts = ""
-  revision = "e386b2658ed20923da8cc9250e552f082899a1ee"
+  revision = "3d8ee2261517413977a62256b7d79644d7ffdc43"
 
 [[projects]]
-  branch = "release-7.0"
-  digest = "1:2f1f3df7def4cc363d48ede8dcd6e9a4f0268a278f64d55f1aaae75b52d38d77"
+  branch = "release-8.0"
+  digest = "1:5e0a4eaf460ad67c1ac99d13753b604a81bec77ac8eacfd0fdc03f04128f2989"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -768,6 +796,7 @@
     "informers/rbac/v1beta1",
     "informers/scheduling",
     "informers/scheduling/v1alpha1",
+    "informers/scheduling/v1beta1",
     "informers/settings",
     "informers/settings/v1alpha1",
     "informers/storage",
@@ -825,6 +854,8 @@
     "kubernetes/typed/rbac/v1beta1/fake",
     "kubernetes/typed/scheduling/v1alpha1",
     "kubernetes/typed/scheduling/v1alpha1/fake",
+    "kubernetes/typed/scheduling/v1beta1",
+    "kubernetes/typed/scheduling/v1beta1/fake",
     "kubernetes/typed/settings/v1alpha1",
     "kubernetes/typed/settings/v1alpha1/fake",
     "kubernetes/typed/storage/v1",
@@ -853,12 +884,14 @@
     "listers/rbac/v1alpha1",
     "listers/rbac/v1beta1",
     "listers/scheduling/v1alpha1",
+    "listers/scheduling/v1beta1",
     "listers/settings/v1alpha1",
     "listers/storage/v1",
     "listers/storage/v1alpha1",
     "listers/storage/v1beta1",
     "pkg/apis/clientauthentication",
     "pkg/apis/clientauthentication/v1alpha1",
+    "pkg/apis/clientauthentication/v1beta1",
     "pkg/version",
     "plugin/pkg/client/auth/exec",
     "plugin/pkg/client/auth/gcp",
@@ -879,6 +912,7 @@
     "transport",
     "util/buffer",
     "util/cert",
+    "util/connrotation",
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
@@ -887,11 +921,11 @@
     "util/workqueue",
   ]
   pruneopts = ""
-  revision = "745ca830039794f7b927b8a2c2a58dcc1e8a0a72"
+  revision = "573fc71f7a51eb0720524b3973d465dcde5566e6"
 
 [[projects]]
-  branch = "release-1.10"
-  digest = "1:34b0b3400ffdc2533ed4ea23721956638c2776ba49ca4c5def71dddcf0cdfd9b"
+  branch = "release-1.11"
+  digest = "1:332f5b5962cb4766ee8db261b948ec6c27a79a0006f1c638b4cbb4a203069aaf"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -920,7 +954,7 @@
     "pkg/util",
   ]
   pruneopts = ""
-  revision = "9de8e796a74d16d2a285165727d04c185ebca6dc"
+  revision = "f8cba74510f397bac80157a6c4ccb0ffbc31b9d0"
 
 [[projects]]
   branch = "master"
@@ -940,16 +974,16 @@
   revision = "fd15ee9cc2f77baa4f31e59e6acbf21146455073"
 
 [[projects]]
-  branch = "master"
-  digest = "1:33e0659135bcc9af7a24a4866f6e22ae22ee030dcf2ce71342149b773499f384"
+  digest = "1:4f5eb833037cc0ba0bf8fe9cae6be9df62c19dd1c869415275c708daa8ccfda5"
   name = "k8s.io/klog"
   packages = ["."]
   pruneopts = ""
-  revision = "8139d8cb77af419532b33dfa7dd09fbc5f1d344f"
+  revision = "a5bc97fbc634d635061f3146511332c7e313a55a"
+  version = "v0.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:d3fdd2e6dafedf0cd13d327cb62c8675d1f309d5587245e3ad35b083589675af"
+  digest = "1:e5d4ca90c0f3862515c98454bb37d4d340f4ceeca60ac3e0a5cb5857360aed7c"
   name = "k8s.io/kube-openapi"
   packages = [
     "cmd/openapi-gen/args",
@@ -960,7 +994,7 @@
     "pkg/util/sets",
   ]
   pruneopts = ""
-  revision = "c59034cc13d587f5ef4e85ca0ade0c1866ae8e1d"
+  revision = "0317810137be915b9cf888946c6e115c1bfac693"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -969,7 +1003,6 @@
     "github.com/apache/thrift/lib/go/thrift",
     "github.com/coreos/bbolt",
     "github.com/gogo/protobuf/jsonpb",
-    "github.com/golang/glog",
     "github.com/golang/mock/gomock",
     "github.com/golang/mock/mockgen",
     "github.com/hashicorp/go-retryablehttp",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -83,23 +83,23 @@
 
  [[override]]
    name = "k8s.io/code-generator"
-   branch = "release-1.10"
+   branch = "release-1.11"
 
  [[override]]
    name = "k8s.io/api"
-   branch = "release-1.10"
+   branch = "release-1.11"
 
  [[override]]
    name = "k8s.io/apimachinery"
-   branch = "release-1.10"
+   branch = "release-1.11"
 
  [[override]]
    name = "k8s.io/apiextensions-apiserver"
-   branch = "release-1.10"
+   branch = "release-1.11"
 
  [[override]]
    name = "k8s.io/client-go"
-   branch = "release-7.0"
+   branch = "release-8.0"
 
 [[constraint]]
   name = "github.com/rakyll/statik"

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -23,7 +23,6 @@
 package versioned
 
 import (
-	glog "github.com/golang/glog"
 	operatorv1 "github.com/m3db/m3db-operator/pkg/client/clientset/versioned/typed/m3dboperator/v1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
@@ -78,7 +77,6 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 
 	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
 	if err != nil {
-		glog.Errorf("failed to create the DiscoveryClient: %v", err)
 		return nil, err
 	}
 	return &cs, nil

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -45,9 +45,10 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		}
 	}
 
-	fakePtr := testing.Fake{}
-	fakePtr.AddReactor("*", "*", testing.ObjectReaction(o))
-	fakePtr.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+	cs := &Clientset{}
+	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
 		ns := action.GetNamespace()
 		watch, err := o.Watch(gvr, ns)
@@ -57,7 +58,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 		return true, watch, nil
 	})
 
-	return &Clientset{fakePtr, &fakediscovery.FakeDiscovery{Fake: &fakePtr}}
+	return cs
 }
 
 // Clientset implements clientset.Interface. Meant to be embedded into a

--- a/pkg/client/clientset/versioned/typed/m3dboperator/v1/fake/fake_m3dbcluster.go
+++ b/pkg/client/clientset/versioned/typed/m3dboperator/v1/fake/fake_m3dbcluster.go
@@ -66,7 +66,7 @@ func (c *FakeM3DBClusters) List(opts v1.ListOptions) (result *m3dboperatorv1.M3D
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &m3dboperatorv1.M3DBClusterList{}
+	list := &m3dboperatorv1.M3DBClusterList{ListMeta: obj.(*m3dboperatorv1.M3DBClusterList).ListMeta}
 	for _, item := range obj.(*m3dboperatorv1.M3DBClusterList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -36,12 +36,16 @@ import (
 	cache "k8s.io/client-go/tools/cache"
 )
 
+// SharedInformerOption defines the functional option type for SharedInformerFactory.
+type SharedInformerOption func(*sharedInformerFactory) *sharedInformerFactory
+
 type sharedInformerFactory struct {
 	client           versioned.Interface
 	namespace        string
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
 	lock             sync.Mutex
 	defaultResync    time.Duration
+	customResync     map[reflect.Type]time.Duration
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -49,23 +53,62 @@ type sharedInformerFactory struct {
 	startedInformers map[reflect.Type]bool
 }
 
-// NewSharedInformerFactory constructs a new instance of sharedInformerFactory
+// WithCustomResyncConfig sets a custom resync period for the specified informer types.
+func WithCustomResyncConfig(resyncConfig map[v1.Object]time.Duration) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		for k, v := range resyncConfig {
+			factory.customResync[reflect.TypeOf(k)] = v
+		}
+		return factory
+	}
+}
+
+// WithTweakListOptions sets a custom filter on all listers of the configured SharedInformerFactory.
+func WithTweakListOptions(tweakListOptions internalinterfaces.TweakListOptionsFunc) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.tweakListOptions = tweakListOptions
+		return factory
+	}
+}
+
+// WithNamespace limits the SharedInformerFactory to the specified namespace.
+func WithNamespace(namespace string) SharedInformerOption {
+	return func(factory *sharedInformerFactory) *sharedInformerFactory {
+		factory.namespace = namespace
+		return factory
+	}
+}
+
+// NewSharedInformerFactory constructs a new instance of sharedInformerFactory for all namespaces.
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
-	return NewFilteredSharedInformerFactory(client, defaultResync, v1.NamespaceAll, nil)
+	return NewSharedInformerFactoryWithOptions(client, defaultResync)
 }
 
 // NewFilteredSharedInformerFactory constructs a new instance of sharedInformerFactory.
 // Listers obtained via this SharedInformerFactory will be subject to the same filters
 // as specified here.
+// Deprecated: Please use NewSharedInformerFactoryWithOptions instead
 func NewFilteredSharedInformerFactory(client versioned.Interface, defaultResync time.Duration, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc) SharedInformerFactory {
-	return &sharedInformerFactory{
+	return NewSharedInformerFactoryWithOptions(client, defaultResync, WithNamespace(namespace), WithTweakListOptions(tweakListOptions))
+}
+
+// NewSharedInformerFactoryWithOptions constructs a new instance of a SharedInformerFactory with additional options.
+func NewSharedInformerFactoryWithOptions(client versioned.Interface, defaultResync time.Duration, options ...SharedInformerOption) SharedInformerFactory {
+	factory := &sharedInformerFactory{
 		client:           client,
-		namespace:        namespace,
-		tweakListOptions: tweakListOptions,
+		namespace:        v1.NamespaceAll,
 		defaultResync:    defaultResync,
 		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),
+		customResync:     make(map[reflect.Type]time.Duration),
 	}
+
+	// Apply all options
+	for _, opt := range options {
+		factory = opt(factory)
+	}
+
+	return factory
 }
 
 // Start initializes all requested informers.
@@ -114,7 +157,13 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
-	informer = newFunc(f.client, f.defaultResync)
+
+	resyncPeriod, exists := f.customResync[informerType]
+	if !exists {
+		resyncPeriod = f.defaultResync
+	}
+
+	informer = newFunc(f.client, resyncPeriod)
 	f.informers[informerType] = informer
 
 	return informer

--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -42,6 +42,7 @@ import (
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -88,6 +89,8 @@ func (deps *testDeps) newController() *Controller {
 		crdClient:     deps.crdClient,
 		podIDProvider: deps.idProvider,
 
+		clusterWorkQueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), clusterWorkQueueName),
+		podWorkQueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), podWorkQueueName),
 		clusterLister:     deps.crdLister,
 		statefulSetLister: deps.statefulSetLister,
 		podLister:         deps.podLister,

--- a/pkg/controller/update_cluster_test.go
+++ b/pkg/controller/update_cluster_test.go
@@ -556,11 +556,10 @@ func TestValidatePlacementWithStatus(t *testing.T) {
 
 	placementMock.EXPECT().Get().AnyTimes()
 
-	testBool, err := controller.validatePlacementWithStatus(cluster)
+	clusterReturn, err := controller.validatePlacementWithStatus(cluster)
 
 	require.NoError(t, err)
-	require.True(t, testBool)
-
+	require.NotNil(t, clusterReturn)
 }
 
 func TestSortPodID(t *testing.T) {

--- a/pkg/k8sops/generators.go
+++ b/pkg/k8sops/generators.go
@@ -93,9 +93,6 @@ func (k *k8sops) GenerateCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 				Plural: m3dboperator.ResourcePlural,
 				Kind:   m3dboperator.ResourceKind,
 			},
-			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
-				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
-			},
 		},
 	}
 }

--- a/pkg/k8sops/generators_test.go
+++ b/pkg/k8sops/generators_test.go
@@ -53,9 +53,6 @@ func TestGenerateCRD(t *testing.T) {
 				Plural: m3dboperator.ResourcePlural,
 				Kind:   m3dboperator.ResourceKind,
 			},
-			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
-				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
-			},
 		},
 	}
 

--- a/pkg/k8sops/k8sops_mock.go
+++ b/pkg/k8sops/k8sops_mock.go
@@ -63,6 +63,7 @@ func (m *MockK8sops) EXPECT() *MockK8sopsMockRecorder {
 
 // ListM3DBCluster mocks base method
 func (m *MockK8sops) ListM3DBCluster() (*v1.M3DBClusterList, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListM3DBCluster")
 	ret0, _ := ret[0].(*v1.M3DBClusterList)
 	ret1, _ := ret[1].(error)
@@ -71,11 +72,13 @@ func (m *MockK8sops) ListM3DBCluster() (*v1.M3DBClusterList, error) {
 
 // ListM3DBCluster indicates an expected call of ListM3DBCluster
 func (mr *MockK8sopsMockRecorder) ListM3DBCluster() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListM3DBCluster", reflect.TypeOf((*MockK8sops)(nil).ListM3DBCluster))
 }
 
 // GetM3DBCluster mocks base method
 func (m *MockK8sops) GetM3DBCluster(namespace, name string) (*v1.M3DBCluster, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetM3DBCluster", namespace, name)
 	ret0, _ := ret[0].(*v1.M3DBCluster)
 	ret1, _ := ret[1].(error)
@@ -84,11 +87,13 @@ func (m *MockK8sops) GetM3DBCluster(namespace, name string) (*v1.M3DBCluster, er
 
 // GetM3DBCluster indicates an expected call of GetM3DBCluster
 func (mr *MockK8sopsMockRecorder) GetM3DBCluster(namespace, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetM3DBCluster", reflect.TypeOf((*MockK8sops)(nil).GetM3DBCluster), namespace, name)
 }
 
 // GetCRD mocks base method
 func (m *MockK8sops) GetCRD(name string) (*v1beta1.CustomResourceDefinition, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCRD", name)
 	ret0, _ := ret[0].(*v1beta1.CustomResourceDefinition)
 	ret1, _ := ret[1].(error)
@@ -97,11 +102,13 @@ func (m *MockK8sops) GetCRD(name string) (*v1beta1.CustomResourceDefinition, err
 
 // GetCRD indicates an expected call of GetCRD
 func (mr *MockK8sopsMockRecorder) GetCRD(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCRD", reflect.TypeOf((*MockK8sops)(nil).GetCRD), name)
 }
 
 // CreateCRD mocks base method
 func (m *MockK8sops) CreateCRD(name string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCRD", name)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -109,11 +116,13 @@ func (m *MockK8sops) CreateCRD(name string) error {
 
 // CreateCRD indicates an expected call of CreateCRD
 func (mr *MockK8sopsMockRecorder) CreateCRD(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCRD", reflect.TypeOf((*MockK8sops)(nil).CreateCRD), name)
 }
 
 // GenerateCRD mocks base method
 func (m *MockK8sops) GenerateCRD() *v1beta1.CustomResourceDefinition {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateCRD")
 	ret0, _ := ret[0].(*v1beta1.CustomResourceDefinition)
 	return ret0
@@ -121,11 +130,13 @@ func (m *MockK8sops) GenerateCRD() *v1beta1.CustomResourceDefinition {
 
 // GenerateCRD indicates an expected call of GenerateCRD
 func (mr *MockK8sopsMockRecorder) GenerateCRD() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateCRD", reflect.TypeOf((*MockK8sops)(nil).GenerateCRD))
 }
 
 // UpdateCRD mocks base method
 func (m *MockK8sops) UpdateCRD(cluster *v1.M3DBCluster) (*v1.M3DBCluster, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCRD", cluster)
 	ret0, _ := ret[0].(*v1.M3DBCluster)
 	ret1, _ := ret[1].(error)
@@ -134,11 +145,13 @@ func (m *MockK8sops) UpdateCRD(cluster *v1.M3DBCluster) (*v1.M3DBCluster, error)
 
 // UpdateCRD indicates an expected call of UpdateCRD
 func (mr *MockK8sopsMockRecorder) UpdateCRD(cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCRD", reflect.TypeOf((*MockK8sops)(nil).UpdateCRD), cluster)
 }
 
 // NewListWatcher mocks base method
 func (m *MockK8sops) NewListWatcher() *cache.ListWatch {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewListWatcher")
 	ret0, _ := ret[0].(*cache.ListWatch)
 	return ret0
@@ -146,11 +159,13 @@ func (m *MockK8sops) NewListWatcher() *cache.ListWatch {
 
 // NewListWatcher indicates an expected call of NewListWatcher
 func (mr *MockK8sopsMockRecorder) NewListWatcher() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewListWatcher", reflect.TypeOf((*MockK8sops)(nil).NewListWatcher))
 }
 
 // GetService mocks base method
 func (m *MockK8sops) GetService(cluster *v1.M3DBCluster, name string) (*v11.Service, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetService", cluster, name)
 	ret0, _ := ret[0].(*v11.Service)
 	ret1, _ := ret[1].(error)
@@ -159,11 +174,13 @@ func (m *MockK8sops) GetService(cluster *v1.M3DBCluster, name string) (*v11.Serv
 
 // GetService indicates an expected call of GetService
 func (mr *MockK8sopsMockRecorder) GetService(cluster, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockK8sops)(nil).GetService), cluster, name)
 }
 
 // DeleteService mocks base method
 func (m *MockK8sops) DeleteService(cluster *v1.M3DBCluster, name string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteService", cluster, name)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -171,11 +188,13 @@ func (m *MockK8sops) DeleteService(cluster *v1.M3DBCluster, name string) error {
 
 // DeleteService indicates an expected call of DeleteService
 func (mr *MockK8sopsMockRecorder) DeleteService(cluster, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteService", reflect.TypeOf((*MockK8sops)(nil).DeleteService), cluster, name)
 }
 
 // EnsureService mocks base method
 func (m *MockK8sops) EnsureService(cluster *v1.M3DBCluster, svc *v11.Service) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureService", cluster, svc)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -183,11 +202,13 @@ func (m *MockK8sops) EnsureService(cluster *v1.M3DBCluster, svc *v11.Service) er
 
 // EnsureService indicates an expected call of EnsureService
 func (mr *MockK8sopsMockRecorder) EnsureService(cluster, svc interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureService", reflect.TypeOf((*MockK8sops)(nil).EnsureService), cluster, svc)
 }
 
 // MultiLabelSelector mocks base method
 func (m *MockK8sops) MultiLabelSelector(kvs map[string]string) v12.ListOptions {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MultiLabelSelector", kvs)
 	ret0, _ := ret[0].(v12.ListOptions)
 	return ret0
@@ -195,11 +216,13 @@ func (m *MockK8sops) MultiLabelSelector(kvs map[string]string) v12.ListOptions {
 
 // MultiLabelSelector indicates an expected call of MultiLabelSelector
 func (mr *MockK8sopsMockRecorder) MultiLabelSelector(kvs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MultiLabelSelector", reflect.TypeOf((*MockK8sops)(nil).MultiLabelSelector), kvs)
 }
 
 // LabelSelector mocks base method
 func (m *MockK8sops) LabelSelector(key, value string) v12.ListOptions {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LabelSelector", key, value)
 	ret0, _ := ret[0].(v12.ListOptions)
 	return ret0
@@ -207,11 +230,13 @@ func (m *MockK8sops) LabelSelector(key, value string) v12.ListOptions {
 
 // LabelSelector indicates an expected call of LabelSelector
 func (mr *MockK8sopsMockRecorder) LabelSelector(key, value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LabelSelector", reflect.TypeOf((*MockK8sops)(nil).LabelSelector), key, value)
 }
 
 // DeleteStatefulSets mocks base method
 func (m *MockK8sops) DeleteStatefulSets(cluster *v1.M3DBCluster, listOpts v12.ListOptions) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteStatefulSets", cluster, listOpts)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -219,11 +244,13 @@ func (m *MockK8sops) DeleteStatefulSets(cluster *v1.M3DBCluster, listOpts v12.Li
 
 // DeleteStatefulSets indicates an expected call of DeleteStatefulSets
 func (mr *MockK8sopsMockRecorder) DeleteStatefulSets(cluster, listOpts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStatefulSets", reflect.TypeOf((*MockK8sops)(nil).DeleteStatefulSets), cluster, listOpts)
 }
 
 // GetStatefulSets mocks base method
 func (m *MockK8sops) GetStatefulSets(cluster *v1.M3DBCluster, listOpts v12.ListOptions) (*v10.StatefulSetList, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStatefulSets", cluster, listOpts)
 	ret0, _ := ret[0].(*v10.StatefulSetList)
 	ret1, _ := ret[1].(error)
@@ -232,11 +259,13 @@ func (m *MockK8sops) GetStatefulSets(cluster *v1.M3DBCluster, listOpts v12.ListO
 
 // GetStatefulSets indicates an expected call of GetStatefulSets
 func (mr *MockK8sopsMockRecorder) GetStatefulSets(cluster, listOpts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStatefulSets", reflect.TypeOf((*MockK8sops)(nil).GetStatefulSets), cluster, listOpts)
 }
 
 // GetPlacementDetails mocks base method
 func (m *MockK8sops) GetPlacementDetails(cluster *v1.M3DBCluster) (map[string]string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPlacementDetails", cluster)
 	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
@@ -245,11 +274,13 @@ func (m *MockK8sops) GetPlacementDetails(cluster *v1.M3DBCluster) (map[string]st
 
 // GetPlacementDetails indicates an expected call of GetPlacementDetails
 func (mr *MockK8sopsMockRecorder) GetPlacementDetails(cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPlacementDetails", reflect.TypeOf((*MockK8sops)(nil).GetPlacementDetails), cluster)
 }
 
 // GetPodsByLabel mocks base method
 func (m *MockK8sops) GetPodsByLabel(cluster *v1.M3DBCluster, listOpts v12.ListOptions) (*v11.PodList, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPodsByLabel", cluster, listOpts)
 	ret0, _ := ret[0].(*v11.PodList)
 	ret1, _ := ret[1].(error)
@@ -258,11 +289,13 @@ func (m *MockK8sops) GetPodsByLabel(cluster *v1.M3DBCluster, listOpts v12.ListOp
 
 // GetPodsByLabel indicates an expected call of GetPodsByLabel
 func (mr *MockK8sopsMockRecorder) GetPodsByLabel(cluster, listOpts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodsByLabel", reflect.TypeOf((*MockK8sops)(nil).GetPodsByLabel), cluster, listOpts)
 }
 
 // CreateStatefulSet mocks base method
 func (m *MockK8sops) CreateStatefulSet(cluster *v1.M3DBCluster, statefulSet *v10.StatefulSet) (*v10.StatefulSet, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateStatefulSet", cluster, statefulSet)
 	ret0, _ := ret[0].(*v10.StatefulSet)
 	ret1, _ := ret[1].(error)
@@ -271,11 +304,13 @@ func (m *MockK8sops) CreateStatefulSet(cluster *v1.M3DBCluster, statefulSet *v10
 
 // CreateStatefulSet indicates an expected call of CreateStatefulSet
 func (mr *MockK8sopsMockRecorder) CreateStatefulSet(cluster, statefulSet interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStatefulSet", reflect.TypeOf((*MockK8sops)(nil).CreateStatefulSet), cluster, statefulSet)
 }
 
 // GetStatefulSet mocks base method
 func (m *MockK8sops) GetStatefulSet(cluster *v1.M3DBCluster, name string) (*v10.StatefulSet, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStatefulSet", cluster, name)
 	ret0, _ := ret[0].(*v10.StatefulSet)
 	ret1, _ := ret[1].(error)
@@ -284,11 +319,13 @@ func (m *MockK8sops) GetStatefulSet(cluster *v1.M3DBCluster, name string) (*v10.
 
 // GetStatefulSet indicates an expected call of GetStatefulSet
 func (mr *MockK8sopsMockRecorder) GetStatefulSet(cluster, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStatefulSet", reflect.TypeOf((*MockK8sops)(nil).GetStatefulSet), cluster, name)
 }
 
 // UpdateStatefulSet mocks base method
 func (m *MockK8sops) UpdateStatefulSet(cluster *v1.M3DBCluster, statefulSet *v10.StatefulSet) (*v10.StatefulSet, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateStatefulSet", cluster, statefulSet)
 	ret0, _ := ret[0].(*v10.StatefulSet)
 	ret1, _ := ret[1].(error)
@@ -297,11 +334,13 @@ func (m *MockK8sops) UpdateStatefulSet(cluster *v1.M3DBCluster, statefulSet *v10
 
 // UpdateStatefulSet indicates an expected call of UpdateStatefulSet
 func (mr *MockK8sopsMockRecorder) UpdateStatefulSet(cluster, statefulSet interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatefulSet", reflect.TypeOf((*MockK8sops)(nil).UpdateStatefulSet), cluster, statefulSet)
 }
 
 // CheckStatefulStatus mocks base method
 func (m *MockK8sops) CheckStatefulStatus(cluster *v1.M3DBCluster, statefulSet *v10.StatefulSet) (*v10.StatefulSet, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckStatefulStatus", cluster, statefulSet)
 	ret0, _ := ret[0].(*v10.StatefulSet)
 	ret1, _ := ret[1].(error)
@@ -310,11 +349,13 @@ func (m *MockK8sops) CheckStatefulStatus(cluster *v1.M3DBCluster, statefulSet *v
 
 // CheckStatefulStatus indicates an expected call of CheckStatefulStatus
 func (mr *MockK8sopsMockRecorder) CheckStatefulStatus(cluster, statefulSet interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckStatefulStatus", reflect.TypeOf((*MockK8sops)(nil).CheckStatefulStatus), cluster, statefulSet)
 }
 
 // Events mocks base method
 func (m *MockK8sops) Events(namespace string) v13.EventInterface {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Events", namespace)
 	ret0, _ := ret[0].(v13.EventInterface)
 	return ret0
@@ -322,5 +363,6 @@ func (m *MockK8sops) Events(namespace string) v13.EventInterface {
 
 // Events indicates an expected call of Events
 func (mr *MockK8sopsMockRecorder) Events(namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Events", reflect.TypeOf((*MockK8sops)(nil).Events), namespace)
 }

--- a/pkg/k8sops/podidentity/provider.go
+++ b/pkg/k8sops/podidentity/provider.go
@@ -108,10 +108,10 @@ func (p *provider) Identity(pod *corev1.Pod, cluster *myspec.M3DBCluster) (*mysp
 			if err != nil {
 				return nil, err
 			}
-			if node.Spec.ExternalID == "" {
+			if node.Spec.DoNotUse_ExternalID == "" {
 				return nil, errEmptyNodeExternalID
 			}
-			id.NodeExternalID = node.Spec.ExternalID
+			id.NodeExternalID = node.Spec.DoNotUse_ExternalID
 		case myspec.PodIdentitySourceNodeSpecProviderID:
 			node, err := p.nodeForPod(pod)
 			if err != nil {

--- a/pkg/k8sops/podidentity/provider_mock.go
+++ b/pkg/k8sops/podidentity/provider_mock.go
@@ -58,6 +58,7 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 
 // Identity mocks base method
 func (m *MockProvider) Identity(pod *v10.Pod, cluster *v1.M3DBCluster) (*v1.PodIdentity, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Identity", pod, cluster)
 	ret0, _ := ret[0].(*v1.PodIdentity)
 	ret1, _ := ret[1].(error)
@@ -66,5 +67,6 @@ func (m *MockProvider) Identity(pod *v10.Pod, cluster *v1.M3DBCluster) (*v1.PodI
 
 // Identity indicates an expected call of Identity
 func (mr *MockProviderMockRecorder) Identity(pod, cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identity", reflect.TypeOf((*MockProvider)(nil).Identity), pod, cluster)
 }

--- a/pkg/k8sops/podidentity/provider_test.go
+++ b/pkg/k8sops/podidentity/provider_test.go
@@ -123,7 +123,7 @@ func TestIdentity(t *testing.T) {
 			pod:  newPodForNode("pod-a", "node-1"),
 			nodes: []runtime.Object{func() runtime.Object {
 				n := newTestNode("node-1")
-				n.Spec.ExternalID = "id1"
+				n.Spec.DoNotUse_ExternalID = "id1"
 				return n
 			}()},
 			cluster: clusterWithSources("foo", myspec.PodIdentitySourceNodeSpecExternalID),

--- a/pkg/m3admin/client_mock.go
+++ b/pkg/m3admin/client_mock.go
@@ -57,6 +57,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // DoHTTPRequest mocks base method
 func (m *MockClient) DoHTTPRequest(action, url string, data *bytes.Buffer) (*http.Response, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DoHTTPRequest", action, url, data)
 	ret0, _ := ret[0].(*http.Response)
 	ret1, _ := ret[1].(error)
@@ -65,5 +66,6 @@ func (m *MockClient) DoHTTPRequest(action, url string, data *bytes.Buffer) (*htt
 
 // DoHTTPRequest indicates an expected call of DoHTTPRequest
 func (mr *MockClientMockRecorder) DoHTTPRequest(action, url, data interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoHTTPRequest", reflect.TypeOf((*MockClient)(nil).DoHTTPRequest), action, url, data)
 }

--- a/pkg/m3admin/namespace/client_mock.go
+++ b/pkg/m3admin/namespace/client_mock.go
@@ -57,6 +57,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // Create mocks base method
 func (m *MockClient) Create(request *admin.NamespaceAddRequest) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", request)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -64,11 +65,13 @@ func (m *MockClient) Create(request *admin.NamespaceAddRequest) error {
 
 // Create indicates an expected call of Create
 func (mr *MockClientMockRecorder) Create(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockClient)(nil).Create), request)
 }
 
 // List mocks base method
 func (m *MockClient) List() (*admin.NamespaceGetResponse, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List")
 	ret0, _ := ret[0].(*admin.NamespaceGetResponse)
 	ret1, _ := ret[1].(error)
@@ -77,11 +80,13 @@ func (m *MockClient) List() (*admin.NamespaceGetResponse, error) {
 
 // List indicates an expected call of List
 func (mr *MockClientMockRecorder) List() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockClient)(nil).List))
 }
 
 // Delete mocks base method
 func (m *MockClient) Delete(namespace string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", namespace)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -89,5 +94,6 @@ func (m *MockClient) Delete(namespace string) error {
 
 // Delete indicates an expected call of Delete
 func (mr *MockClientMockRecorder) Delete(namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClient)(nil).Delete), namespace)
 }

--- a/pkg/m3admin/placement/client_mock.go
+++ b/pkg/m3admin/placement/client_mock.go
@@ -59,6 +59,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // Init mocks base method
 func (m *MockClient) Init(request *admin.PlacementInitRequest) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Init", request)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -66,11 +67,13 @@ func (m *MockClient) Init(request *admin.PlacementInitRequest) error {
 
 // Init indicates an expected call of Init
 func (mr *MockClientMockRecorder) Init(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockClient)(nil).Init), request)
 }
 
 // Get mocks base method
 func (m *MockClient) Get() (placement.Placement, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get")
 	ret0, _ := ret[0].(placement.Placement)
 	ret1, _ := ret[1].(error)
@@ -79,11 +82,13 @@ func (m *MockClient) Get() (placement.Placement, error) {
 
 // Get indicates an expected call of Get
 func (mr *MockClientMockRecorder) Get() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get))
 }
 
 // Delete mocks base method
 func (m *MockClient) Delete() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -91,11 +96,13 @@ func (m *MockClient) Delete() error {
 
 // Delete indicates an expected call of Delete
 func (mr *MockClientMockRecorder) Delete() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClient)(nil).Delete))
 }
 
 // Add mocks base method
 func (m *MockClient) Add(instance placementpb.Instance) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Add", instance)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -103,11 +110,13 @@ func (m *MockClient) Add(instance placementpb.Instance) error {
 
 // Add indicates an expected call of Add
 func (mr *MockClientMockRecorder) Add(instance interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockClient)(nil).Add), instance)
 }
 
 // Remove mocks base method
 func (m *MockClient) Remove(id string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove", id)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -115,11 +124,13 @@ func (m *MockClient) Remove(id string) error {
 
 // Remove indicates an expected call of Remove
 func (mr *MockClientMockRecorder) Remove(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockClient)(nil).Remove), id)
 }
 
 // Replace mocks base method
 func (m *MockClient) Replace(leavingInstanceID string, newInstance placementpb.Instance) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Replace", leavingInstanceID, newInstance)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -127,5 +138,6 @@ func (m *MockClient) Replace(leavingInstanceID string, newInstance placementpb.I
 
 // Replace indicates an expected call of Replace
 func (mr *MockClientMockRecorder) Replace(leavingInstanceID, newInstance interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Replace", reflect.TypeOf((*MockClient)(nil).Replace), leavingInstanceID, newInstance)
 }


### PR DESCRIPTION
Pulls in more recent client versions and updates usage of a
to-be-deprecated field.

Tested by running against a 1.10 and 1.11 cluster.

Had to make some changes to ensure the same status update functions work
across both versions and didn't trigger constant loop updates. Also
modified the re-enqueue logic to refresh our view of the world rather
than re-entering the loop.