### PR TITLE
Minor code cleanup of m3db_operator

### DIFF
--- a/pkg/controller/update_cluster.go
+++ b/pkg/controller/update_cluster.go
@@ -65,11 +65,7 @@ func (c *Controller) reconcileNamespaces(cluster *myspec.M3DBCluster) error {
 		return err
 	}
 
-	if err := c.createNamespaces(cluster, resp.Registry); err != nil {
-		return err
-	}
-
-	return nil
+	return c.createNamespaces(cluster, resp.Registry)
 }
 
 // createNamespaces will attempt to create in the cluster all namespaces which

--- a/pkg/controller/update_cluster_test.go
+++ b/pkg/controller/update_cluster_test.go
@@ -76,7 +76,7 @@ func TestReconcileNamespaces(t *testing.T) {
 
 	registry := &dbns.Registry{
 		Namespaces: map[string]*dbns.NamespaceOptions{
-			"a": &dbns.NamespaceOptions{},
+			"a": {},
 		},
 	}
 	resp := &admin.NamespaceGetResponse{
@@ -104,7 +104,7 @@ func TestCleanupNamespaces(t *testing.T) {
 	defer deps.cleanup()
 
 	registry := &dbns.Registry{Namespaces: map[string]*dbns.NamespaceOptions{
-		"foo": &dbns.NamespaceOptions{},
+		"foo": {},
 	}}
 
 	nsMock.EXPECT().Delete("foo").Return(nil)
@@ -159,7 +159,7 @@ func TestNamespacesToCreate(t *testing.T) {
 		{
 			registry: &dbns.Registry{
 				Namespaces: map[string]*dbns.NamespaceOptions{
-					"foo": &dbns.NamespaceOptions{},
+					"foo": {},
 				},
 			},
 			namespaces: []myspec.Namespace{
@@ -169,7 +169,7 @@ func TestNamespacesToCreate(t *testing.T) {
 		{
 			registry: &dbns.Registry{
 				Namespaces: map[string]*dbns.NamespaceOptions{
-					"foo": &dbns.NamespaceOptions{},
+					"foo": {},
 				},
 			},
 			namespaces: []myspec.Namespace{
@@ -197,7 +197,7 @@ func TestNamespacesToDelete(t *testing.T) {
 		{
 			registry: &dbns.Registry{
 				Namespaces: map[string]*dbns.NamespaceOptions{
-					"foo": &dbns.NamespaceOptions{},
+					"foo": {},
 				},
 			},
 			namespaces: []myspec.Namespace{
@@ -207,7 +207,7 @@ func TestNamespacesToDelete(t *testing.T) {
 		{
 			registry: &dbns.Registry{
 				Namespaces: map[string]*dbns.NamespaceOptions{
-					"foo": &dbns.NamespaceOptions{},
+					"foo": {},
 				},
 			},
 			namespaces: []myspec.Namespace{
@@ -218,7 +218,7 @@ func TestNamespacesToDelete(t *testing.T) {
 		{
 			registry: &dbns.Registry{
 				Namespaces: map[string]*dbns.NamespaceOptions{
-					"foo": &dbns.NamespaceOptions{},
+					"foo": {},
 				},
 			},
 			namespaces: []myspec.Namespace{

--- a/pkg/k8sops/generators.go
+++ b/pkg/k8sops/generators.go
@@ -29,7 +29,7 @@ import (
 	"github.com/m3db/m3db-operator/pkg/k8sops/labels"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -86,9 +86,15 @@ func (k *k8sops) GenerateCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 			Name: m3dboperator.Name,
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   m3dboperator.GroupName,
-			Version: m3dboperator.Version,
-			Scope:   apiextensionsv1beta1.NamespaceScoped,
+			Group: m3dboperator.GroupName,
+			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+				{
+					Name:    m3dboperator.Version,
+					Served:  true,
+					Storage: true,
+				},
+			},
+			Scope: apiextensionsv1beta1.NamespaceScoped,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 				Plural: m3dboperator.ResourcePlural,
 				Kind:   m3dboperator.ResourceKind,

--- a/pkg/k8sops/generators_test.go
+++ b/pkg/k8sops/generators_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/m3db/m3db-operator/pkg/k8sops/labels"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,9 +46,15 @@ func TestGenerateCRD(t *testing.T) {
 			Name: m3dboperator.Name,
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   m3dboperator.GroupName,
-			Version: m3dboperator.Version,
-			Scope:   apiextensionsv1beta1.NamespaceScoped,
+			Group: m3dboperator.GroupName,
+			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+				{
+					Name:    m3dboperator.Version,
+					Served:  true,
+					Storage: true,
+				},
+			},
+			Scope: apiextensionsv1beta1.NamespaceScoped,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 				Plural: m3dboperator.ResourcePlural,
 				Kind:   m3dboperator.ResourceKind,
@@ -145,7 +151,7 @@ func TestGenerateStatefulSet(t *testing.T) {
 						},
 					},
 					Containers: []v1.Container{
-						v1.Container{
+						{
 							Name: ssName,
 							SecurityContext: &v1.SecurityContext{
 								Privileged: &[]bool{true}[0],
@@ -167,7 +173,7 @@ func TestGenerateStatefulSet(t *testing.T) {
 							Image:           clusterSpec.Image,
 							ImagePullPolicy: "Always",
 							Env: []v1.EnvVar{
-								v1.EnvVar{
+								{
 									Name: "NAMESPACE",
 									ValueFrom: &v1.EnvVarSource{
 										FieldRef: &v1.ObjectFieldSelector{
@@ -178,19 +184,19 @@ func TestGenerateStatefulSet(t *testing.T) {
 							},
 							Ports: generateContainerPorts(),
 							VolumeMounts: []v1.VolumeMount{
-								v1.VolumeMount{
+								{
 									Name:      _dataVolumeName,
 									MountPath: _dataDirectory,
 								},
-								v1.VolumeMount{
+								{
 									Name:      "cache",
 									MountPath: "/var/lib/m3kv/",
 								},
-								v1.VolumeMount{
+								{
 									Name:      "pod-identity",
 									MountPath: "/etc/m3db/pod-identity",
 								},
-								v1.VolumeMount{
+								{
 									Name:      _configurationName,
 									MountPath: _configurationDirectory,
 								},
@@ -208,13 +214,13 @@ func TestGenerateStatefulSet(t *testing.T) {
 						},
 					},
 					Volumes: []v1.Volume{
-						v1.Volume{
+						{
 							Name: "cache",
 							VolumeSource: v1.VolumeSource{
 								EmptyDir: &v1.EmptyDirVolumeSource{},
 							},
 						},
-						v1.Volume{
+						{
 							Name: "pod-identity",
 							VolumeSource: v1.VolumeSource{
 								DownwardAPI: &v1.DownwardAPIVolumeSource{
@@ -229,7 +235,7 @@ func TestGenerateStatefulSet(t *testing.T) {
 								},
 							},
 						},
-						v1.Volume{
+						{
 							Name: _configurationName,
 							VolumeSource: v1.VolumeSource{
 								ConfigMap: &v1.ConfigMapVolumeSource{

--- a/pkg/k8sops/statefulset.go
+++ b/pkg/k8sops/statefulset.go
@@ -31,7 +31,7 @@ import (
 	"github.com/m3db/m3db-operator/pkg/k8sops/podidentity"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -241,7 +241,7 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
-						v1.Container{
+						{
 							Name: ssName,
 							SecurityContext: &v1.SecurityContext{
 								Privileged: &[]bool{true}[0],
@@ -262,7 +262,7 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 							Image:           image,
 							ImagePullPolicy: "Always",
 							Env: []v1.EnvVar{
-								v1.EnvVar{
+								{
 									Name: "NAMESPACE",
 									ValueFrom: &v1.EnvVarSource{
 										FieldRef: &v1.ObjectFieldSelector{
@@ -273,11 +273,11 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 							},
 							Ports: nil,
 							VolumeMounts: []v1.VolumeMount{
-								v1.VolumeMount{
+								{
 									Name:      _dataVolumeName,
 									MountPath: _dataDirectory,
 								},
-								v1.VolumeMount{
+								{
 									Name:      "cache",
 									MountPath: "/var/lib/m3kv/",
 								},
@@ -286,7 +286,7 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 						},
 					},
 					Volumes: []v1.Volume{
-						v1.Volume{
+						{
 							Name: "cache",
 							VolumeSource: v1.VolumeSource{
 								EmptyDir: &v1.EmptyDirVolumeSource{},


### PR DESCRIPTION
 - Run gofmt simplify on generators_test.go, statefulset.go, and update_cluster_test.go
 - Replace Version(deprecated) with Versions in GenerateCRD
 - Fix superfluous err!=nil check in update_cluster.go

These changes should be harmless and non-breaking :).
