### PR TITLE
[rbac] add event patch permission

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -39,7 +39,7 @@ rules:
   verbs: ["*"]
 - apiGroups: [""]
   resources: ["events"]
-  verbs: ["create"]
+  verbs: ["create", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch"]

--- a/helm/m3db-operator/templates/cluster_role.yaml
+++ b/helm/m3db-operator/templates/cluster_role.yaml
@@ -29,7 +29,7 @@ rules:
   verbs: ["*"]
 - apiGroups: [""]
   resources: ["events"]
-  verbs: ["create"]
+  verbs: ["create", "patch"]
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
`client-go` sometimes needs to patch events in addition to creating
them.