### PR TITLE
[api] represent durations as strings

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -390,6 +390,14 @@
   version = "v2.0.1"
 
 [[projects]]
+  digest = "1:1d7e1867c49a6dd9856598ef7c3123604ea3daabf5b83f303ff457bcbc410b1d"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = ""
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
+
+[[projects]]
   digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
@@ -1016,6 +1024,7 @@
     "github.com/m3db/stackmurmur3",
     "github.com/m3db/vellum/regexp",
     "github.com/m3db/vellum/utf8",
+    "github.com/pkg/errors",
     "github.com/rakyll/statik/fs",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -104,3 +104,7 @@
 [[constraint]]
   name = "github.com/rakyll/statik"
   version = "0.1.5"
+
+[[constraint]]
+  name = "github.com/pkg/errors"
+  version = "0.8.1"

--- a/cmd/m3db-operator/main.go
+++ b/cmd/m3db-operator/main.go
@@ -81,8 +81,6 @@ func main() {
 	var cfg zap.Config
 	if _develLog {
 		cfg = zap.NewDevelopmentConfig()
-		cfg.DisableStacktrace = true
-		cfg.DisableCaller = true
 		cfg.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
 	} else {
 		cfg = zap.NewProductionConfig()
@@ -90,6 +88,8 @@ func main() {
 	if _debugLog {
 		cfg.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
 	}
+	cfg.DisableStacktrace = true
+	cfg.DisableCaller = true
 	logger, err := cfg.Build()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error building logger: %v", err)

--- a/docs/api.md
+++ b/docs/api.md
@@ -106,7 +106,7 @@ IndexOptions defines parameters for indexing.
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | enabled | Enabled controls whether metric indexing is enabled. | bool | false |
-| blockSize | BlockSize controls the index block size. | time.Duration | false |
+| blockSize | BlockSize controls the index block size. | string | false |
 
 [Back to TOC](#table-of-contents)
 
@@ -145,12 +145,12 @@ RetentionOptions defines parameters for data retention.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| retentionPeriod | RetentionPeriod controls how long data for the namespace is retained. | time.Duration | false |
-| blockSize | BlockSize controls the block size for the namespace. | time.Duration | false |
-| bufferFuture | BufferFuture controls how far in the future metrics can be written. | time.Duration | false |
-| bufferPast | BufferPast controls how far in the past metrics can be written. | time.Duration | false |
+| retentionPeriod | RetentionPeriod controls how long data for the namespace is retained. | string | false |
+| blockSize | BlockSize controls the block size for the namespace. | string | false |
+| bufferFuture | BufferFuture controls how far in the future metrics can be written. | string | false |
+| bufferPast | BufferPast controls how far in the past metrics can be written. | string | false |
 | blockDataExpiry | BlockDataExpiry controls the block expiry. | bool | false |
-| blockDataExpiryAfterNotAccessPeriod | BlockDataExpiry controls the not after access period for expiration. | time.Duration | false |
+| blockDataExpiryAfterNotAccessPeriod | BlockDataExpiry controls the not after access period for expiration. | string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/apis/m3dboperator/v1alpha1/namespace.go
+++ b/pkg/apis/m3dboperator/v1alpha1/namespace.go
@@ -20,8 +20,6 @@
 
 package v1alpha1
 
-import "time"
-
 // Namespace defines an M3DB namespace or points to a preset M3DB namespace.
 type Namespace struct {
 	// Name is the namespace name.
@@ -38,22 +36,22 @@ type Namespace struct {
 // RetentionOptions defines parameters for data retention.
 type RetentionOptions struct {
 	// RetentionPeriod controls how long data for the namespace is retained.
-	RetentionPeriod time.Duration `json:"retentionPeriod,omitempty"`
+	RetentionPeriod string `json:"retentionPeriod,omitempty"`
 
 	// BlockSize controls the block size for the namespace.
-	BlockSize time.Duration `json:"blockSize,omitempty"`
+	BlockSize string `json:"blockSize,omitempty"`
 
 	// BufferFuture controls how far in the future metrics can be written.
-	BufferFuture time.Duration `json:"bufferFuture,omitempty"`
+	BufferFuture string `json:"bufferFuture,omitempty"`
 
 	// BufferPast controls how far in the past metrics can be written.
-	BufferPast time.Duration `json:"bufferPast,omitempty"`
+	BufferPast string `json:"bufferPast,omitempty"`
 
 	// BlockDataExpiry controls the block expiry.
 	BlockDataExpiry bool `json:"blockDataExpiry,omitempty"`
 
 	// BlockDataExpiry controls the not after access period for expiration.
-	BlockDataExpiryAfterNotAccessPeriod time.Duration `json:"blockDataExpiryAfterNotAccessPeriod,omitempty"`
+	BlockDataExpiryAfterNotAccessPeriod string `json:"blockDataExpiryAfterNotAccessPeriod,omitempty"`
 }
 
 // IndexOptions defines parameters for indexing.
@@ -62,7 +60,7 @@ type IndexOptions struct {
 	Enabled bool `json:"enabled,omitempty"`
 
 	// BlockSize controls the index block size.
-	BlockSize time.Duration `json:"blockSize,omitempty"`
+	BlockSize string `json:"blockSize,omitempty"`
 }
 
 // NamespaceOptions defines parameters for an M3DB namespace. See

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -395,6 +395,7 @@ func (c *Controller) handleClusterUpdate(cluster *myspec.M3DBCluster) error {
 	}
 
 	if err := c.reconcileNamespaces(cluster); err != nil {
+		c.recorder.WarningEvent(cluster, eventer.ReasonFailedCreate, "failed to create namespace: %s", err)
 		c.logger.Error("error reconciling namespaces", zap.Error(err))
 		return err
 	}

--- a/pkg/m3admin/client_test.go
+++ b/pkg/m3admin/client_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	retryhttp "github.com/hashicorp/go-retryablehttp"
+	pkgerrors "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -106,7 +107,7 @@ func TestClient_DoHTTPRequest_Err(t *testing.T) {
 
 			cl := NewClient(WithHTTPClient(retry))
 			_, err := cl.DoHTTPRequest("GET", s.URL, nil)
-			assert.Equal(t, test.expErr, err)
+			assert.Equal(t, test.expErr, pkgerrors.Cause(err))
 		})
 	}
 }

--- a/pkg/m3admin/namespace/namespace.go
+++ b/pkg/m3admin/namespace/namespace.go
@@ -47,7 +47,7 @@ func RequestFromSpec(ns myspec.Namespace) (*admin.NamespaceAddRequest, error) {
 	}
 
 	if ns.Options != nil {
-		opts, err := requestOptsFromAPI(ns.Options)
+		opts, err := m3dbNamespaceOptsFromSpec(ns.Options)
 		if err != nil {
 			return nil, err
 		}
@@ -68,7 +68,7 @@ func RequestFromSpec(ns myspec.Namespace) (*admin.NamespaceAddRequest, error) {
 		return nil, fmt.Errorf("preset '%s' not found", ns.Preset)
 	}
 
-	requestOpts, err := requestOptsFromAPI(&opts)
+	requestOpts, err := m3dbNamespaceOptsFromSpec(&opts)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func RequestFromSpec(ns myspec.Namespace) (*admin.NamespaceAddRequest, error) {
 	}, nil
 }
 
-func requestOptsFromAPI(opts *myspec.NamespaceOptions) (*m3ns.NamespaceOptions, error) {
+func m3dbNamespaceOptsFromSpec(opts *myspec.NamespaceOptions) (*m3ns.NamespaceOptions, error) {
 	retentionOpts, err := m3dbRetentionOptsFromSpec(opts.RetentionOptions)
 	if err != nil {
 		return nil, err

--- a/pkg/m3admin/namespace/namespace.go
+++ b/pkg/m3admin/namespace/namespace.go
@@ -80,12 +80,12 @@ func RequestFromSpec(ns myspec.Namespace) (*admin.NamespaceAddRequest, error) {
 }
 
 func requestOptsFromAPI(opts *myspec.NamespaceOptions) (*m3ns.NamespaceOptions, error) {
-	retentionOpts, err := retentionOptsFromAPI(opts.RetentionOptions)
+	retentionOpts, err := m3dbRetentionOptsFromSpec(opts.RetentionOptions)
 	if err != nil {
 		return nil, err
 	}
 
-	indexOpts, err := indexOptsFromAPI(opts.IndexOptions)
+	indexOpts, err := m3dbIndexOptsFromSpec(opts.IndexOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func requestOptsFromAPI(opts *myspec.NamespaceOptions) (*m3ns.NamespaceOptions, 
 	}, nil
 }
 
-func retentionOptsFromAPI(opts myspec.RetentionOptions) (*m3ns.RetentionOptions, error) {
+func m3dbRetentionOptsFromSpec(opts myspec.RetentionOptions) (*m3ns.RetentionOptions, error) {
 	retention, err := time.ParseDuration(opts.RetentionPeriod)
 	if err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ func retentionOptsFromAPI(opts myspec.RetentionOptions) (*m3ns.RetentionOptions,
 	}, nil
 }
 
-func indexOptsFromAPI(opts myspec.IndexOptions) (*m3ns.IndexOptions, error) {
+func m3dbIndexOptsFromSpec(opts myspec.IndexOptions) (*m3ns.IndexOptions, error) {
 	blockSize, err := time.ParseDuration(opts.BlockSize)
 	if err != nil {
 		return nil, err

--- a/pkg/m3admin/namespace/namespace_test.go
+++ b/pkg/m3admin/namespace/namespace_test.go
@@ -34,9 +34,9 @@ import (
 )
 
 func TestRequestFromSpec(t *testing.T) {
-	preset10s2d, err := requestOptsFromAPI(&presetTenSecondsTwoDaysIndexed)
+	preset10s2d, err := m3dbNamespaceOptsFromSpec(&presetTenSecondsTwoDaysIndexed)
 	require.NoError(t, err)
-	preset1m40d, err := requestOptsFromAPI(&presetOneMinuteFourtyDaysIndexed)
+	preset1m40d, err := m3dbNamespaceOptsFromSpec(&presetOneMinuteFourtyDaysIndexed)
 	require.NoError(t, err)
 
 	tests := []struct {

--- a/pkg/m3admin/namespace/namespace_test.go
+++ b/pkg/m3admin/namespace/namespace_test.go
@@ -177,7 +177,7 @@ func TestRetentionOptsFromAPI(t *testing.T) {
 		BlockDataExpiryAfterNotAccessPeriod: time.Duration(5 * time.Second).String(),
 	}
 
-	nsOpts, err := retentionOptsFromAPI(opts)
+	nsOpts, err := m3dbRetentionOptsFromSpec(opts)
 	assert.NoError(t, err)
 
 	assert.Equal(t, int64(1000000000), nsOpts.RetentionPeriodNanos)
@@ -194,7 +194,7 @@ func TestIndexOptsFromAPI(t *testing.T) {
 		BlockSize: time.Second.String(),
 	}
 
-	iOpts, err := indexOptsFromAPI(opts)
+	iOpts, err := m3dbIndexOptsFromSpec(opts)
 	assert.NoError(t, err)
 
 	assert.True(t, iOpts.Enabled)

--- a/pkg/m3admin/namespace/namespace_test.go
+++ b/pkg/m3admin/namespace/namespace_test.go
@@ -30,9 +30,15 @@ import (
 	"github.com/m3db/m3/src/query/generated/proto/admin"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRequestFromSpec(t *testing.T) {
+	preset10s2d, err := requestOptsFromAPI(&presetTenSecondsTwoDaysIndexed)
+	require.NoError(t, err)
+	preset1m40d, err := requestOptsFromAPI(&presetOneMinuteFourtyDaysIndexed)
+	require.NoError(t, err)
+
 	tests := []struct {
 		ns     myspec.Namespace
 		req    *admin.NamespaceAddRequest
@@ -44,13 +50,13 @@ func TestRequestFromSpec(t *testing.T) {
 		},
 		{
 			ns: myspec.Namespace{
-				Name: "foo",
+				Name: "empty",
 			},
 			expErr: true,
 		},
 		{
 			ns: myspec.Namespace{
-				Name:    "foo",
+				Name:    "badpreset",
 				Preset:  "a",
 				Options: &myspec.NamespaceOptions{},
 			},
@@ -58,7 +64,45 @@ func TestRequestFromSpec(t *testing.T) {
 		},
 		{
 			ns: myspec.Namespace{
-				Name: "foo",
+				Name: "validcustom",
+				Options: &myspec.NamespaceOptions{
+					BootstrapEnabled: true,
+					RetentionOptions: myspec.RetentionOptions{
+						RetentionPeriod:                     "1s",
+						BlockSize:                           "1s",
+						BufferFuture:                        "1s",
+						BufferPast:                          "1s",
+						BlockDataExpiry:                     true,
+						BlockDataExpiryAfterNotAccessPeriod: "1s",
+					},
+					IndexOptions: myspec.IndexOptions{
+						BlockSize: "1s",
+						Enabled:   true,
+					},
+				},
+			},
+			req: &admin.NamespaceAddRequest{
+				Name: "validcustom",
+				Options: &m3ns.NamespaceOptions{
+					BootstrapEnabled: true,
+					RetentionOptions: &m3ns.RetentionOptions{
+						RetentionPeriodNanos:                     1000000000,
+						BlockSizeNanos:                           1000000000,
+						BufferFutureNanos:                        1000000000,
+						BufferPastNanos:                          1000000000,
+						BlockDataExpiry:                          true,
+						BlockDataExpiryAfterNotAccessPeriodNanos: 1000000000,
+					},
+					IndexOptions: &m3ns.IndexOptions{
+						BlockSizeNanos: 1000000000,
+						Enabled:        true,
+					},
+				},
+			},
+		},
+		{
+			ns: myspec.Namespace{
+				Name: "invalidcustom",
 				Options: &myspec.NamespaceOptions{
 					BootstrapEnabled: true,
 					RetentionOptions: myspec.RetentionOptions{
@@ -70,7 +114,7 @@ func TestRequestFromSpec(t *testing.T) {
 				},
 			},
 			req: &admin.NamespaceAddRequest{
-				Name: "foo",
+				Name: "invalidcustom",
 				Options: &m3ns.NamespaceOptions{
 					BootstrapEnabled: true,
 					RetentionOptions: &m3ns.RetentionOptions{
@@ -81,6 +125,7 @@ func TestRequestFromSpec(t *testing.T) {
 					},
 				},
 			},
+			expErr: true,
 		},
 		{
 			ns: myspec.Namespace{
@@ -96,7 +141,7 @@ func TestRequestFromSpec(t *testing.T) {
 			},
 			req: &admin.NamespaceAddRequest{
 				Name:    "foo",
-				Options: requestOptsFromAPI(&presetTenSecondsTwoDaysIndexed),
+				Options: preset10s2d,
 			},
 		},
 		{
@@ -106,7 +151,7 @@ func TestRequestFromSpec(t *testing.T) {
 			},
 			req: &admin.NamespaceAddRequest{
 				Name:    "foo",
-				Options: requestOptsFromAPI(&presetOneMinuteFourtyDaysIndexed),
+				Options: preset1m40d,
 			},
 		},
 	}
@@ -116,6 +161,7 @@ func TestRequestFromSpec(t *testing.T) {
 		if test.expErr {
 			assert.Error(t, err)
 		} else {
+			assert.NoError(t, err)
 			assert.Equal(t, test.req, req)
 		}
 	}
@@ -123,15 +169,16 @@ func TestRequestFromSpec(t *testing.T) {
 
 func TestRetentionOptsFromAPI(t *testing.T) {
 	opts := myspec.RetentionOptions{
-		RetentionPeriod:                     time.Second,
-		BlockSize:                           2 * time.Second,
-		BufferFuture:                        3 * time.Second,
-		BufferPast:                          4 * time.Second,
+		RetentionPeriod:                     time.Duration(time.Second).String(),
+		BlockSize:                           time.Duration(2 * time.Second).String(),
+		BufferFuture:                        time.Duration(3 * time.Second).String(),
+		BufferPast:                          time.Duration(4 * time.Second).String(),
 		BlockDataExpiry:                     true,
-		BlockDataExpiryAfterNotAccessPeriod: 5 * time.Second,
+		BlockDataExpiryAfterNotAccessPeriod: time.Duration(5 * time.Second).String(),
 	}
 
-	nsOpts := retentionOptsFromAPI(opts)
+	nsOpts, err := retentionOptsFromAPI(opts)
+	assert.NoError(t, err)
 
 	assert.Equal(t, int64(1000000000), nsOpts.RetentionPeriodNanos)
 	assert.Equal(t, int64(2000000000), nsOpts.BlockSizeNanos)
@@ -144,10 +191,11 @@ func TestRetentionOptsFromAPI(t *testing.T) {
 func TestIndexOptsFromAPI(t *testing.T) {
 	opts := myspec.IndexOptions{
 		Enabled:   true,
-		BlockSize: time.Second,
+		BlockSize: time.Second.String(),
 	}
 
-	iOpts := indexOptsFromAPI(opts)
+	iOpts, err := indexOptsFromAPI(opts)
+	assert.NoError(t, err)
 
 	assert.True(t, iOpts.Enabled)
 	assert.Equal(t, int64(1000000000), iOpts.BlockSizeNanos)

--- a/pkg/m3admin/namespace/presets.go
+++ b/pkg/m3admin/namespace/presets.go
@@ -50,16 +50,16 @@ var (
 		RepairEnabled:     false,
 		SnapshotEnabled:   true,
 		RetentionOptions: myspec.RetentionOptions{
-			RetentionPeriod:                     2 * 24 * time.Hour,
-			BlockSize:                           2 * time.Hour,
-			BufferFuture:                        10 * time.Minute,
-			BufferPast:                          10 * time.Minute,
+			RetentionPeriod:                     time.Duration(2 * 24 * time.Hour).String(),
+			BlockSize:                           time.Duration(2 * time.Hour).String(),
+			BufferFuture:                        time.Duration(10 * time.Minute).String(),
+			BufferPast:                          time.Duration(10 * time.Minute).String(),
 			BlockDataExpiry:                     true,
-			BlockDataExpiryAfterNotAccessPeriod: 5 * time.Minute,
+			BlockDataExpiryAfterNotAccessPeriod: time.Duration(5 * time.Minute).String(),
 		},
 		IndexOptions: myspec.IndexOptions{
 			Enabled:   true,
-			BlockSize: 2 * time.Hour,
+			BlockSize: time.Duration(2 * time.Hour).String(),
 		},
 	}
 
@@ -71,16 +71,16 @@ var (
 		RepairEnabled:     false,
 		SnapshotEnabled:   true,
 		RetentionOptions: myspec.RetentionOptions{
-			RetentionPeriod:                     40 * 24 * time.Hour,
-			BlockSize:                           24 * time.Hour,
-			BufferFuture:                        10 * time.Minute,
-			BufferPast:                          20 * time.Minute,
+			RetentionPeriod:                     time.Duration(40 * 24 * time.Hour).String(),
+			BlockSize:                           time.Duration(24 * time.Hour).String(),
+			BufferFuture:                        time.Duration(10 * time.Minute).String(),
+			BufferPast:                          time.Duration(20 * time.Minute).String(),
 			BlockDataExpiry:                     true,
-			BlockDataExpiryAfterNotAccessPeriod: 10 * time.Minute,
+			BlockDataExpiryAfterNotAccessPeriod: time.Duration(10 * time.Minute).String(),
 		},
 		IndexOptions: myspec.IndexOptions{
 			Enabled:   true,
-			BlockSize: 24 * time.Hour,
+			BlockSize: time.Duration(24 * time.Hour).String(),
 		},
 	}
 )

--- a/pkg/m3admin/namespace/presets.go
+++ b/pkg/m3admin/namespace/presets.go
@@ -50,16 +50,16 @@ var (
 		RepairEnabled:     false,
 		SnapshotEnabled:   true,
 		RetentionOptions: myspec.RetentionOptions{
-			RetentionPeriod:                     time.Duration(2 * 24 * time.Hour).String(),
-			BlockSize:                           time.Duration(2 * time.Hour).String(),
-			BufferFuture:                        time.Duration(10 * time.Minute).String(),
-			BufferPast:                          time.Duration(10 * time.Minute).String(),
+			RetentionPeriod:                     (2 * 24 * time.Hour).String(),
+			BlockSize:                           (2 * time.Hour).String(),
+			BufferFuture:                        (10 * time.Minute).String(),
+			BufferPast:                          (10 * time.Minute).String(),
 			BlockDataExpiry:                     true,
-			BlockDataExpiryAfterNotAccessPeriod: time.Duration(5 * time.Minute).String(),
+			BlockDataExpiryAfterNotAccessPeriod: (5 * time.Minute).String(),
 		},
 		IndexOptions: myspec.IndexOptions{
 			Enabled:   true,
-			BlockSize: time.Duration(2 * time.Hour).String(),
+			BlockSize: (2 * time.Hour).String(),
 		},
 	}
 
@@ -71,16 +71,16 @@ var (
 		RepairEnabled:     false,
 		SnapshotEnabled:   true,
 		RetentionOptions: myspec.RetentionOptions{
-			RetentionPeriod:                     time.Duration(40 * 24 * time.Hour).String(),
-			BlockSize:                           time.Duration(24 * time.Hour).String(),
-			BufferFuture:                        time.Duration(10 * time.Minute).String(),
-			BufferPast:                          time.Duration(20 * time.Minute).String(),
+			RetentionPeriod:                     (40 * 24 * time.Hour).String(),
+			BlockSize:                           (24 * time.Hour).String(),
+			BufferFuture:                        (10 * time.Minute).String(),
+			BufferPast:                          (20 * time.Minute).String(),
 			BlockDataExpiry:                     true,
-			BlockDataExpiryAfterNotAccessPeriod: time.Duration(10 * time.Minute).String(),
+			BlockDataExpiryAfterNotAccessPeriod: (10 * time.Minute).String(),
 		},
 		IndexOptions: myspec.IndexOptions{
 			Enabled:   true,
-			BlockSize: time.Duration(24 * time.Hour).String(),
+			BlockSize: (24 * time.Hour).String(),
 		},
 	}
 )


### PR DESCRIPTION
We'd previously been using `time.Duration` as the type of various
durations in the namespace options. I swear this was working a while ago
so I'm not sure if something changes with `client-go` or if I totally
missed and issue. This changes the CRD to use strings and parse the
durations separately, which should fix the issue of the string
durations failing to parse.

Also added some context to the namespace create error and include it in
an event.