### PR TITLE
[controller] unwrap errors from m3admin

### DIFF
--- a/pkg/controller/add_cluster.go
+++ b/pkg/controller/add_cluster.go
@@ -35,6 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 
+	pkgerrors "github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -53,7 +54,7 @@ func (c *Controller) EnsurePlacement(cluster *myspec.M3DBCluster) error {
 	// Get placement
 	plClient := c.adminClient.placementClientForCluster(cluster)
 	_, err := plClient.Get()
-	if err == m3admin.ErrNotFound {
+	if pkgerrors.Cause(err) == m3admin.ErrNotFound {
 		placementInitRequest := &admin.PlacementInitRequest{
 			NumShards:         cluster.Spec.NumberOfShards,
 			ReplicationFactor: cluster.Spec.ReplicationFactor,

--- a/pkg/controller/add_cluster_test.go
+++ b/pkg/controller/add_cluster_test.go
@@ -26,12 +26,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/m3db/m3db-operator/pkg/m3admin"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes/utils/pointer"
-	"github.com/m3db/m3db-operator/pkg/m3admin"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/rakyll/statik/fs"
 	"github.com/stretchr/testify/assert"

--- a/pkg/controller/add_cluster_test.go
+++ b/pkg/controller/add_cluster_test.go
@@ -85,7 +85,7 @@ func TestEnsurePlacement(t *testing.T) {
 	err = controller.EnsurePlacement(cluster)
 	assert.NoError(t, err)
 
-	placementMock.EXPECT().Get().Return(nil, errors.New("foo"))
+	placementMock.EXPECT().Get().Return(nil, errors.New("placement client not available"))
 	err = controller.EnsurePlacement(cluster)
 	assert.Error(t, err)
 }

--- a/pkg/controller/update_cluster.go
+++ b/pkg/controller/update_cluster.go
@@ -47,6 +47,7 @@ import (
 	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
 
+	pkgerrors "github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -109,7 +110,7 @@ func (c *Controller) pruneNamespaces(cluster *myspec.M3DBCluster, registry *dbns
 			continue
 		}
 
-		if err == m3admin.ErrNotFound {
+		if pkgerrors.Cause(err) == m3admin.ErrNotFound {
 			c.logger.Info("namespace has already been deleted", zap.String("namespace", ns))
 			continue
 		}
@@ -165,7 +166,7 @@ func (c *Controller) validatePlacementWithStatus(cluster *myspec.M3DBCluster) (*
 		return cluster, nil
 	}
 
-	if err != m3admin.ErrNotFound {
+	if pkgerrors.Cause(err) != m3admin.ErrNotFound {
 		err := fmt.Errorf("error from m3admin placement get: %v", err)
 		c.logger.Error(err.Error())
 		runtime.HandleError(err)


### PR DESCRIPTION
We were checking against the wrapped errors which caused the placement
and namespace controller actions to behave incorrectly.

Fixes #96