### PR TITLE
[api] support per-isogroup storageclasses

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -57,8 +57,9 @@ IsolationGroup defines the name of zone as well attributes for the zone configur
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| name | Name | string | false |
-| numInstances | NumInstances defines the number of instances | int32 | false |
+| name | Name | string | true |
+| numInstances | NumInstances defines the number of instances | int32 | true |
+| storageClassName | StorageClassName is the name of the StorageClass to use for this isolation group. This allows ensuring that PVs will be created in the same zone as the pinned statefulset on Kubernetes < 1.12 (when topology aware volume scheduling was introduced). Only has effect if the clusters `dataDirVolumeClaimTemplate` is non-nil. If set, the volume claim template will have its storageClassName field overridden per-isolationgroup. If unset the storageClassName of the volumeClaimTemplate will be used. | string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/example/m3db-cluster-per-zone-storageclass.yaml
+++ b/example/m3db-cluster-per-zone-storageclass.yaml
@@ -33,7 +33,7 @@ metadata:
 spec:
   image: quay.io/m3db/m3dbnode:latest
   replicationFactor: 3
-  numberOfShards: 4
+  numberOfShards: 1024
   isolationGroups:
   - name: us-east1-b
     numInstances: 1

--- a/example/m3db-cluster-per-zone-storageclass.yaml
+++ b/example/m3db-cluster-per-zone-storageclass.yaml
@@ -1,0 +1,64 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fast-east1-b
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+  zone: us-east1-b
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fast-east1-c
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+  zone: us-east1-c
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fast-east1-d
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+  zone: us-east1-d
+---
+apiVersion: operator.m3db.io/v1alpha1
+kind: M3DBCluster
+metadata:
+  name: m3db-cluster-pv
+spec:
+  image: quay.io/m3db/m3dbnode:latest
+  replicationFactor: 3
+  numberOfShards: 4
+  isolationGroups:
+  - name: us-east1-b
+    numInstances: 1
+    storageClassName: fast-east1-b
+  - name: us-east1-c
+    numInstances: 1
+    storageClassName: fast-east1-c
+  - name: us-east1-d
+    numInstances: 1
+    storageClassName: fast-east1-d
+  namespaces:
+  - name: metrics-10s:2d
+    preset: 10s:2d
+  podIdentityConfig:
+    # Using no sources will default to just PodName, which is what we want as
+    # remote PVs can move around with the pod
+    sources: []
+  dataDirVolumeClaimTemplate:
+    metadata:
+      name: m3db-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      # this field will be overwritten per-statefulset
+      storageClassName: unused
+      resources:
+        requests:
+          storage: 100Gi

--- a/example/m3db-cluster.yaml
+++ b/example/m3db-cluster.yaml
@@ -16,7 +16,7 @@ spec:
   namespaces:
     - name: metrics-10s:2d
       preset: 10s:2d
-  resources:
+  containerResources:
     requests:
       memory: 4Gi
       cpu: '1'

--- a/pkg/apis/m3dboperator/v1alpha1/cluster.go
+++ b/pkg/apis/m3dboperator/v1alpha1/cluster.go
@@ -213,10 +213,20 @@ type ClusterSpec struct {
 // IsolationGroup defines the name of zone as well attributes for the zone configuration
 type IsolationGroup struct {
 	// Name
-	Name string `json:"name,omitempty" yaml:"name"`
+	Name string `json:"name"`
 
 	// NumInstances defines the number of instances
-	NumInstances int32 `json:"numInstances,omitempty" yaml:"numInstances"`
+	NumInstances int32 `json:"numInstances"`
+
+	// StorageClassName is the name of the StorageClass to use for this isolation
+	// group. This allows ensuring that PVs will be created in the same zone as
+	// the pinned statefulset on Kubernetes < 1.12 (when topology aware volume
+	// scheduling was introduced). Only has effect if the clusters
+	// `dataDirVolumeClaimTemplate` is non-nil. If set, the volume claim template
+	// will have its storageClassName field overridden per-isolationgroup. If
+	// unset the storageClassName of the volumeClaimTemplate will be used.
+	// +optional
+	StorageClassName string `json:"storageClassName,omitempty"`
 }
 
 // GetByName fetches an IsolationGroup by name.

--- a/pkg/k8sops/generators_test.go
+++ b/pkg/k8sops/generators_test.go
@@ -303,6 +303,27 @@ func TestGenerateStatefulSet(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, newSS)
 	assert.Equal(t, ss, newSS)
+
+	// Reset spec and fixture, test per-isogroup storageclasses
+	ss = baseSS.DeepCopy()
+	fixture = getFixture("testM3DBCluster.yaml", t)
+	fixture.Spec.IsolationGroups[0].StorageClassName = "foo"
+	ss.Spec.VolumeClaimTemplates[0].Spec.StorageClassName = pointer.StringPtr("foo")
+
+	newSS, err = GenerateStatefulSet(fixture, isolationGroup, *instanceAmount)
+	assert.NoError(t, err)
+	assert.NotNil(t, newSS)
+	assert.Equal(t, ss, newSS)
+
+	// Ensure changing another isogroup doesn't affect this statefulset
+	ss = baseSS.DeepCopy()
+	fixture = getFixture("testM3DBCluster.yaml", t)
+	fixture.Spec.IsolationGroups[1].StorageClassName = "foo"
+
+	newSS, err = GenerateStatefulSet(fixture, isolationGroup, *instanceAmount)
+	assert.NoError(t, err)
+	assert.NotNil(t, newSS)
+	assert.Equal(t, ss, newSS)
 }
 
 func TestGenerateM3DBService(t *testing.T) {

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -2,6 +2,10 @@
 
 set -ex
 
+function cleanup() {
+  pkill -f "kubectl proxy"
+}
+
 function main() {
   readonly NAMESPACE="m3db-e2e-test-1"
 
@@ -40,10 +44,11 @@ function main() {
     done
   fi
 
+  trap cleanup EXIT
+
   kubectl proxy &
   go clean -testcache
   go test -v -tags integration ./integration/e2e
-  pkill -f "kubectl proxy"
 }
 
 main


### PR DESCRIPTION
Users running Kubernetes < 1.12, in which topology-aware volume
scheduling was introduced, cannot use a single storageclass for all
their statefulsets as there is no guarantee that the PV for a pod will
be created in the zone the pod is pinned to. This can cause pods to be
stuck in an unschedulable state.

This allows users to specify a StorageClass per-statefulset (zone). This
solves the above problem as a single StorageClass can be created with
attributes to specify that PVs created with it will be in a given zone
(see
https://v1-11.docs.kubernetes.io/docs/concepts/storage/storage-classes/).

Fixes #92