### PR TITLE
[controller] fix incorrect label selectors

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -564,7 +564,8 @@ func instancesInIsoGroup(pl m3placement.Placement, isoGroup string) []m3placemen
 // This func is currently read-only, but if we end up modifying statefulsets
 // we'll have to deepcopy.
 func (c *Controller) getChildStatefulSets(cluster *myspec.M3DBCluster) ([]*appsv1.StatefulSet, error) {
-	statefulSets, err := c.statefulSetLister.StatefulSets(cluster.Namespace).List(klabels.Set(cluster.Labels).AsSelector())
+	labels := labels.BaseLabels(cluster)
+	statefulSets, err := c.statefulSetLister.StatefulSets(cluster.Namespace).List(klabels.Set(labels).AsSelector())
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("error listing statefulsets: %v", err))
 		return nil, err

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -97,9 +97,24 @@ func TestGetChildStatefulSets(t *testing.T) {
 		{
 			cluster: newMeta("cluster1", map[string]string{"foo": "bar"}),
 			sets: []*metav1.ObjectMeta{
-				newMeta("set1", map[string]string{"foo": "bar"}),
+				newMeta("set1", map[string]string{
+					"foo": "bar",
+					"operator.m3db.io/app":     "m3db",
+					"operator.m3db.io/cluster": "cluster1",
+				}),
 			},
 			expChildren: []string{"set1"},
+		},
+		{
+			cluster: newMeta("cluster1", map[string]string{"foo": "bar"}),
+			sets: []*metav1.ObjectMeta{
+				newMeta("set1", map[string]string{
+					"foo": "bar",
+					"operator.m3db.io/app":     "m3db",
+					"operator.m3db.io/cluster": "cluster2",
+				}),
+			},
+			expChildren: []string{},
 		},
 	}
 

--- a/pkg/controller/update_cluster.go
+++ b/pkg/controller/update_cluster.go
@@ -180,8 +180,8 @@ func (c *Controller) validatePlacementWithStatus(cluster *myspec.M3DBCluster) (*
 		ReplicationFactor: cluster.Spec.ReplicationFactor,
 	}
 
-	targetLabels := map[string]string{}
-	for k, v := range cluster.Labels {
+	targetLabels := labels.BaseLabels(cluster)
+	for k, v := range cluster.Spec.Labels {
 		targetLabels[k] = v
 	}
 	targetLabels[labels.Component] = labels.ComponentM3DBNode

--- a/pkg/k8sops/generators_test.go
+++ b/pkg/k8sops/generators_test.go
@@ -122,8 +122,7 @@ func TestGenerateStatefulSet(t *testing.T) {
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
-			ServiceName:         "m3dbnode-m3db-cluster",
-			PodManagementPolicy: "Parallel",
+			ServiceName: "m3dbnode-m3db-cluster",
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},

--- a/pkg/k8sops/statefulset.go
+++ b/pkg/k8sops/statefulset.go
@@ -229,8 +229,7 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 			Labels: objLabels,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			ServiceName:         HeadlessServiceName(clusterName),
-			PodManagementPolicy: "Parallel",
+			ServiceName: HeadlessServiceName(clusterName),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: objLabels,
 			},


### PR DESCRIPTION
We had been constructing the wrong selectors when querying children
pods if the cluster had custom labels.