### PR TITLE
[scripts] add script for migrating etcd data

### DIFF
--- a/scripts/migrate_etcd_0.2_0.3.sh
+++ b/scripts/migrate_etcd_0.2_0.3.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -exo pipefail
+
+if [[ "$1" == "-h" || -z "$ETCD_NS" || -z "$ETCD_POD" || -z "$M3DB_NS" || -z "$M3DB_CLUSTER" ]]; then
+  echo "Script for migrating etcd data from m3db-operator 0.2 -> 0.3"
+  echo "Usage: ETCD_NS=<namespace> ETCD_POD=<pod> M3DB_NS=<namespace> M3DB_CLUSTER=<cluster_name> ./migrate_etcd_0.2_0.3.sh"
+  exit 0
+fi
+
+CLUSTER=$M3DB_CLUSTER
+NS=$M3DB_NS
+
+if ! kubectl get -n "$NS" m3dbcluster "$CLUSTER" > /dev/null; then
+  echo "Could not find m3dbcluster $CLUSTER in namespace $NS"
+  exit 1
+fi
+
+ENV="$NS/$CLUSTER"
+echo "Copying namespace and placement data from env=default_env to env=$ENV"
+
+kubectl exec -n "$ETCD_NS" "$ETCD_POD" -- env ETCDCTL_API=3 etcdctl get _sd.placement/default_env/m3db | kubectl exec -n "$ETCD_NS" "$ETCD_POD" -- env ETCDCTL_API=3 etcdctl put "_sd.placement/$ENV/m3db"
+kubectl exec -n "$ETCD_NS" "$ETCD_POD" -- env ETCDCTL_API=3 etcdctl get _kv/default_env/m3db.node.namespaces | kubectl exec -n "$ETCD_NS" "$ETCD_POD" -- env ETCDCTL_API=3 etcdctl put "_kv/$ENV/m3db.node.namespaces"


### PR DESCRIPTION
In the next release of the operator we'll be changing the default m3db
configmap, and thus how data is stored in etcd. This provides a script
that will let users migrate their data from one etcd keyspace to another
based on their cluster name.

Instructions for using the script to be included in release notes.