### PR TITLE
[m3admin] don't set per-environment header

### DIFF
--- a/pkg/controller/m3admin_client.go
+++ b/pkg/controller/m3admin_client.go
@@ -96,9 +96,7 @@ func newMultiAdminClient(adminOpts []m3admin.Option, logger *zap.Logger) *multiA
 }
 
 func (m *multiAdminClient) adminClientForCluster(cluster *myspec.M3DBCluster) m3admin.Client {
-	env := k8sops.DefaultM3ClusterEnvironmentName(cluster)
-	opts := append(m.adminOpts, m3admin.WithEnvironment(env))
-	return m.adminClientFn(opts...)
+	return m.adminClientFn(m.adminOpts...)
 }
 
 func (m *multiAdminClient) namespaceClientForCluster(cluster *myspec.M3DBCluster) namespace.Client {


### PR DESCRIPTION
We added per-environment headers to support the case where a user was
changing the environment and we didn't want a race based on which nodes
got the new config first. However, this ends up adding more
complications. Let's assume that environments will always stay the same
(if using the default configmap we never change it) and make this logic
easier.