### PR TITLE
[api] allow specifying pod tolerations

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -51,6 +51,7 @@ ClusterSpec defines the desired state for a M3 cluster to be converge to.
 | podSecurityContext | PodSecurityContext allows the user to specify an optional security context for pods. | *corev1.PodSecurityContext | false |
 | securityContext | SecurityContext allows the user to specify a container-level security context. | *corev1.SecurityContext | false |
 | labels | Labels sets the base labels that will be applied to resources created by the cluster. // TODO(schallert): design doc on labeling scheme. | map[string]string | false |
+| tolerations | Tolerations sets the tolerations that will be applied to all M3DB pods. | []corev1.Toleration | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/apis/m3dboperator/v1alpha1/cluster.go
+++ b/pkg/apis/m3dboperator/v1alpha1/cluster.go
@@ -223,6 +223,10 @@ type ClusterSpec struct {
 	// Labels sets the base labels that will be applied to resources created by
 	// the cluster. // TODO(schallert): design doc on labeling scheme.
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels"`
+
+	// Tolerations sets the tolerations that will be applied to all M3DB pods.
+	// +optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // IsolationGroup defines the name of zone as well attributes for the zone configuration

--- a/pkg/apis/m3dboperator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/m3dboperator/v1alpha1/zz_generated.deepcopy.go
@@ -100,6 +100,13 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/k8sops/fixtures/testM3DBCluster.yaml
+++ b/pkg/k8sops/fixtures/testM3DBCluster.yaml
@@ -44,3 +44,7 @@ spec:
           storage: 1Gi
         limits:
           storage: 1Gi
+  tolerations:
+  - key: m3db-dedicated
+    effect: NoSchedule
+    operator: Exists

--- a/pkg/k8sops/generators.go
+++ b/pkg/k8sops/generators.go
@@ -136,6 +136,7 @@ func GenerateStatefulSet(
 	m3dbContainer.Resources = clusterSpec.ContainerResources
 	m3dbContainer.Ports = generateContainerPorts()
 	statefulSet.Spec.Template.Spec.Affinity = GenerateStatefulSetAffinity(isolationGroup)
+	statefulSet.Spec.Template.Spec.Tolerations = cluster.Spec.Tolerations
 
 	// Set owner ref so sts will be GC'd when the cluster is deleted
 	clusterRef := GenerateOwnerRef(cluster)

--- a/pkg/k8sops/generators_test.go
+++ b/pkg/k8sops/generators_test.go
@@ -243,6 +243,13 @@ func TestGenerateStatefulSet(t *testing.T) {
 							},
 						},
 					},
+					Tolerations: []v1.Toleration{
+						{
+							Key:      "m3db-dedicated",
+							Effect:   "NoSchedule",
+							Operator: "Exists",
+						},
+					},
 				},
 			},
 			VolumeClaimTemplates: []v1.PersistentVolumeClaim{
@@ -316,6 +323,17 @@ func TestGenerateStatefulSet(t *testing.T) {
 	ss = baseSS.DeepCopy()
 	fixture = getFixture("testM3DBCluster.yaml", t)
 	fixture.Spec.IsolationGroups[1].StorageClassName = "foo"
+
+	newSS, err = GenerateStatefulSet(fixture, isolationGroup, *instanceAmount)
+	assert.NoError(t, err)
+	assert.NotNil(t, newSS)
+	assert.Equal(t, ss, newSS)
+
+	// Test empty tolerations
+	ss = baseSS.DeepCopy()
+	ss.Spec.Template.Spec.Tolerations = nil
+	fixture = getFixture("testM3DBCluster.yaml", t)
+	fixture.Spec.Tolerations = nil
 
 	newSS, err = GenerateStatefulSet(fixture, isolationGroup, *instanceAmount)
 	assert.NoError(t, err)


### PR DESCRIPTION
Some users wish to use taints/tolerations to pin M3DB instances to
dedicated nodes, and keep other pods off of them. This allows specifying
tolerations in the cluster spec.

Note that we currently allow specifying tolerations on the cluster level
and not the `isolationgroup` level, as it seems like most common use
cases would be setting aside nodes for M3DB using a single taint rather
than a per-zone taint. If user requests for per-isogroup tolerations
arise we can reconsider.