### PR TITLE
[m3admin] restore per-environment header

### DIFF
--- a/pkg/controller/m3admin_client.go
+++ b/pkg/controller/m3admin_client.go
@@ -96,7 +96,9 @@ func newMultiAdminClient(adminOpts []m3admin.Option, logger *zap.Logger) *multiA
 }
 
 func (m *multiAdminClient) adminClientForCluster(cluster *myspec.M3DBCluster) m3admin.Client {
-	return m.adminClientFn(m.adminOpts...)
+	env := k8sops.DefaultM3ClusterEnvironmentName(cluster)
+	opts := append(m.adminOpts, m3admin.WithEnvironment(env))
+	return m.adminClientFn(opts...)
 }
 
 func (m *multiAdminClient) namespaceClientForCluster(cluster *myspec.M3DBCluster) namespace.Client {


### PR DESCRIPTION
This reverts commit 45e6abb4acc9edb6a18d04ffe449956c2d2b8b19.

We made that change under the assumption that m3coordinator would use
the environment in its config file as the default if none was set, but
it turns out it always defaults to `default_env`. Instead we'll add
warning to the documentation that users must always set their env to
`$NAMESPACE/$CLUSTER` if using a custom config.