### PR TITLE
[controller] fix pod removal when diff > 1

### DIFF
--- a/cmd/m3db-operator/main.go
+++ b/cmd/m3db-operator/main.go
@@ -53,7 +53,7 @@ import (
 
 const (
 	// Informers will resync on this interval
-	_informerSyncDuration = 5 * time.Minute
+	_informerSyncDuration = time.Minute
 )
 
 var (
@@ -65,6 +65,7 @@ var (
 	_useProxy     bool
 	_debugLog     bool
 	_develLog     bool
+	_humanTime    bool
 )
 
 func init() {
@@ -72,6 +73,7 @@ func init() {
 	flag.StringVar(&_masterURL, "masterhost", "http://127.0.0.1:8001", "Full url to k8s api server")
 	flag.BoolVar(&_debugLog, "debug", false, "enable debug logging")
 	flag.BoolVar(&_develLog, "devel", false, "enable development logging mode")
+	flag.BoolVar(&_humanTime, "human-time", false, "print human-friendly timestamps")
 	flag.BoolVar(&_useProxy, "proxy", false, "use kubectl proxy for cluster communication")
 	flag.Parse()
 }
@@ -86,6 +88,9 @@ func main() {
 	}
 	if _debugLog {
 		cfg.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
+	}
+	if _humanTime {
+		cfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	}
 	cfg.DisableStacktrace = true
 	cfg.DisableCaller = true

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -480,7 +480,7 @@ func (c *Controller) handleClusterUpdate(cluster *myspec.M3DBCluster) error {
 		desired := group.NumInstances
 		// Number of pods currently in the group.
 		current := *set.Spec.Replicas
-		// Nunber of instances currently in the placement.
+		// Number of instances in the group AND currently in the placement.
 		inPlacement := int32(len(instancesInIsoGroup(placement, group.Name)))
 
 		setLogger := c.logger.With(

--- a/pkg/controller/update_cluster.go
+++ b/pkg/controller/update_cluster.go
@@ -51,6 +51,12 @@ import (
 	"go.uber.org/zap"
 )
 
+var (
+	errEmptyPodList      = errors.New("cannot find removal candidate in empty list")
+	errNoPodsInPlacement = errors.New("no pods were found in the placement")
+	errPodNotInPlacement = errors.New("instance not found in placement")
+)
+
 // reconcileNamespaces will delete any namespaces currently in the cluster that
 // aren't part of the cluster spec, and create any that are present in the spec
 // but not in the cluster.
@@ -321,7 +327,6 @@ func (c *Controller) checkPodsForReplacement(
 	}
 
 	for _, pod := range sortedPods {
-
 		clusterPodID, err := c.podIDProvider.Identity(pod.pod, cluster)
 		if err != nil {
 			return "", nil, err
@@ -337,13 +342,12 @@ func (c *Controller) checkPodsForReplacement(
 
 				if !reflect.DeepEqual(*clusterPodID, instancePodID) {
 					return inst.ID(), pod.pod, nil
-
 				}
 			}
 		}
 	}
-	return "", nil, nil
 
+	return "", nil, nil
 }
 
 func (c *Controller) replacePodInPlacement(
@@ -426,7 +430,7 @@ func (c *Controller) expandPlacementForSet(cluster *myspec.M3DBCluster, set *app
 // shrinkPlacementForSet takes a StatefulSet that needs to be shrunk and
 // removes the last pod in the StatefulSet from the active placement, enabling
 // the StatefulSet size to be decreased once the remove completes.
-func (c *Controller) shrinkPlacementForSet(cluster *myspec.M3DBCluster, set *appsv1.StatefulSet) error {
+func (c *Controller) shrinkPlacementForSet(cluster *myspec.M3DBCluster, set *appsv1.StatefulSet, pl placement.Placement) error {
 	selector := klabels.SelectorFromSet(set.Labels)
 	pods, err := c.podLister.Pods(cluster.Namespace).List(selector)
 	if err != nil {
@@ -434,47 +438,68 @@ func (c *Controller) shrinkPlacementForSet(cluster *myspec.M3DBCluster, set *app
 		return err
 	}
 
-	removePod, err := findPodToRemove(pods)
+	_, removeInst, err := c.findPodInstanceToRemove(cluster, pl, pods)
 	if err != nil {
 		c.logger.Error("error finding pod to remove", zap.Error(err))
 		return err
 	}
 
-	removePodID, err := c.podIDProvider.Identity(removePod, cluster)
-	if err != nil {
-		return err
-	}
-
-	idStr, err := podidentity.IdentityJSON(removePodID)
-	if err != nil {
-		return err
-	}
-
-	c.logger.Info("removing pod from placement", zap.String("pod", removePod.Name))
-	return c.adminClient.placementClientForCluster(cluster).Remove(idStr)
+	c.logger.Info("removing pod from placement", zap.String("instance", removeInst.ID()))
+	return c.adminClient.placementClientForCluster(cluster).Remove(removeInst.ID())
 }
 
-// findPodToRemove returns the pod name with the highest ordinal number in the
-// stateful set so that we remove from the placement the pod that will be
-// deleted when the set size is scaled down.
-func findPodToRemove(pods []*corev1.Pod) (*corev1.Pod, error) {
+// findPodInstanceToRemove returns the pod (and associated placement instace)
+// with the highest ordinal number in the stateful set AND in the placement, so
+// that we remove from the placement the pod that will be deleted when the set
+// size is scaled down.
+func (c *Controller) findPodInstanceToRemove(cluster *myspec.M3DBCluster, pl placement.Placement, pods []*corev1.Pod) (*corev1.Pod, placement.Instance, error) {
 	if len(pods) == 0 {
-		return nil, errors.New("cannot find removal candidate in empty list")
+		return nil, nil, errEmptyPodList
 	}
 
 	podIDs, err := sortPods(pods)
 	if err != nil {
-		return nil, fmt.Errorf("cannot sort pods: %v", err)
+		return nil, nil, pkgerrors.WithMessage(err, "cannot sort pods")
 	}
 
-	lastPod := podIDs[len(podIDs)-1].pod
+	for i := len(podIDs) - 1; i >= 0; i-- {
+		pod := podIDs[i].pod
+		inst, err := c.findPodInPlacement(cluster, pl, pod)
+		if err == errPodNotInPlacement {
+			// If the instance is already out of the placement, continue to the next
+			// one.
+			continue
+		}
+		if err != nil {
+			return nil, nil, pkgerrors.WithMessage(err, "error finding pod in placement")
+		}
+		return pod, inst, nil
+	}
 
-	return lastPod, nil
+	return nil, nil, errNoPodsInPlacement
+}
+
+// findPodInPlacement looks up a pod in the placement. Equality is based on
+// whether a pods identity matches a placement instance's ID.
+func (c *Controller) findPodInPlacement(cluster *myspec.M3DBCluster, pl placement.Placement, pod *corev1.Pod) (placement.Instance, error) {
+	id, err := c.podIDProvider.Identity(pod, cluster)
+	if err != nil {
+		return nil, err
+	}
+	idStr, err := podidentity.IdentityJSON(id)
+	if err != nil {
+		return nil, err
+	}
+	inst, ok := pl.Instance(idStr)
+	if !ok {
+		return nil, errPodNotInPlacement
+	}
+	return inst, nil
 }
 
 func sortPods(pods []*corev1.Pod) ([]podID, error) {
 	if pods == nil {
-		return nil, fmt.Errorf("no pods to sort")
+		return nil, errEmptyPodList
 	}
 
 	podIDs := make([]podID, len(pods))

--- a/pkg/controller/update_cluster.go
+++ b/pkg/controller/update_cluster.go
@@ -465,7 +465,7 @@ func (c *Controller) findPodInstanceToRemove(cluster *myspec.M3DBCluster, pl pla
 	for i := len(podIDs) - 1; i >= 0; i-- {
 		pod := podIDs[i].pod
 		inst, err := c.findPodInPlacement(cluster, pl, pod)
-		if err == errPodNotInPlacement {
+		if pkgerrors.Cause(err) == errPodNotInPlacement {
 			// If the instance is already out of the placement, continue to the next
 			// one.
 			continue

--- a/pkg/m3admin/namespace/client.go
+++ b/pkg/m3admin/namespace/client.go
@@ -141,7 +141,7 @@ func (n *namespaceClient) List() (*admin.NamespaceGetResponse, error) {
 		return nil, errors.New("nil registry from coordinator")
 	}
 
-	n.logger.Info("namespace retrieved")
+	n.logger.Debug("namespace retrieved")
 	return data, nil
 }
 

--- a/pkg/m3admin/placement/client.go
+++ b/pkg/m3admin/placement/client.go
@@ -133,7 +133,7 @@ func (p *placementClient) Add(instance placementpb.Instance) error {
 	if err != nil {
 		return err
 	}
-	p.logger.Info("successfully add instance to placement")
+	p.logger.Debug("successfully add instance to placement")
 	return nil
 }
 

--- a/pkg/m3admin/placement/client.go
+++ b/pkg/m3admin/placement/client.go
@@ -115,7 +115,7 @@ func (p *placementClient) Get() (m3placement.Placement, error) {
 	if data.Placement == nil {
 		return nil, errors.New("nil placement fetch")
 	}
-	p.logger.Info("placement retreived")
+	p.logger.Debug("placement retreived")
 	return m3placement.NewPlacementFromProto(data.Placement)
 }
 


### PR DESCRIPTION
There was a bug in the instance removal logic that would continuously
try to remove the last pod in a set even if it had already been removed
from the placement. This fixes that.