### PR TITLE
[health] use dbnode health/bootstrap endpoints

### DIFF
--- a/pkg/k8sops/generators.go
+++ b/pkg/k8sops/generators.go
@@ -43,10 +43,8 @@ const (
 	_probeInitialDelaySeconds = 10
 	_probeFailureThreshold    = 15
 
-	// TODO(schallert): switch to dbnode's endpoint instead of coordinator after
-	// https://github.com/m3db/m3/issues/996
-	_probePort       = 7201
 	_probePathHealth = "/health"
+	_probePathReady  = "/bootstrappedinplacementornoplacement"
 
 	_dataDirectory             = "/var/lib/m3db/"
 	_dataVolumeName            = "m3db-data"

--- a/pkg/k8sops/generators_test.go
+++ b/pkg/k8sops/generators_test.go
@@ -89,7 +89,7 @@ func TestGenerateStatefulSet(t *testing.T) {
 		FailureThreshold:    _probeFailureThreshold,
 		Handler: v1.Handler{
 			HTTPGet: &v1.HTTPGetAction{
-				Port:   intstr.FromInt(_probePort),
+				Port:   intstr.FromInt(PortM3DBHTTPNode),
 				Path:   _probePathHealth,
 				Scheme: v1.URISchemeHTTP,
 			},
@@ -101,8 +101,10 @@ func TestGenerateStatefulSet(t *testing.T) {
 		InitialDelaySeconds: _probeInitialDelaySeconds,
 		FailureThreshold:    _probeFailureThreshold,
 		Handler: v1.Handler{
-			Exec: &v1.ExecAction{
-				Command: []string{_healthFileName},
+			HTTPGet: &v1.HTTPGetAction{
+				Port:   intstr.FromInt(PortM3DBHTTPNode),
+				Path:   _probePathReady,
+				Scheme: v1.URISchemeHTTP,
 			},
 		},
 	}

--- a/pkg/k8sops/statefulset.go
+++ b/pkg/k8sops/statefulset.go
@@ -71,7 +71,7 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 		FailureThreshold:    _probeFailureThreshold,
 		Handler: v1.Handler{
 			HTTPGet: &v1.HTTPGetAction{
-				Port:   intstr.FromInt(_probePort),
+				Port:   intstr.FromInt(PortM3DBHTTPNode),
 				Path:   _probePathHealth,
 				Scheme: v1.URISchemeHTTP,
 			},
@@ -83,8 +83,10 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 		InitialDelaySeconds: _probeInitialDelaySeconds,
 		FailureThreshold:    _probeFailureThreshold,
 		Handler: v1.Handler{
-			Exec: &v1.ExecAction{
-				Command: []string{_healthFileName},
+			HTTPGet: &v1.HTTPGetAction{
+				Port:   intstr.FromInt(PortM3DBHTTPNode),
+				Path:   _probePathReady,
+				Scheme: v1.URISchemeHTTP,
 			},
 		},
 	}


### PR DESCRIPTION
Now that M3DB exposes health and bootstrapped endpoints immediately we
can leverage those rather than the crazy health check script.