### PR TITLE
Add SYS_RESOURCE security context capability if not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,9 +117,9 @@ test-all: clean-all install-ci-tools verify-gen lint metalint test-all-gen bins 
 	@echo "--- $@"
 
 .PHONY: test
-test: test-base
+test: install-ci-tools test-base
 	@echo "--- $@"
-	gocov convert $(coverfile) | gocov report
+	@PATH=$(combined_bin_paths):$(PATH) gocov convert $(coverfile) | gocov report
 
 .PHONY: test-e2e
 test-e2e:

--- a/pkg/k8sops/generators_test.go
+++ b/pkg/k8sops/generators_test.go
@@ -173,6 +173,9 @@ func TestGenerateStatefulSet(t *testing.T) {
 							ReadinessProbe: readiness,
 							SecurityContext: &v1.SecurityContext{
 								RunAsUser: pointer.Int64Ptr(20),
+								Capabilities: &v1.Capabilities{
+									Add: []v1.Capability{v1.Capability("SYS_RESOURCE")},
+								},
 							},
 							Command: []string{
 								"m3dbnode",

--- a/pkg/k8sops/statefulset.go
+++ b/pkg/k8sops/statefulset.go
@@ -47,8 +47,6 @@ var (
 	errEmptyNodeAffinityValues = errors.New("node affinity term values cannot be empty")
 )
 
-// NewBaseProbe returns a probe configured for default ports.
-
 // NewBaseStatefulSet returns a base configured stateful set.
 func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBCluster, instanceCount int32) *appsv1.StatefulSet {
 	ic := instanceCount
@@ -95,25 +93,15 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 		},
 	}
 
-	// Add SYS_RESOURCE security capability if not set (required to raise
+	// If security context is nil, add one with SYS_RESOURCE (required to raise
 	// rlimit nofile from the process in container)
 	specSecurityCtx := cluster.Spec.SecurityContext
 	if specSecurityCtx == nil {
-		specSecurityCtx = &v1.SecurityContext{}
-	}
-	if specSecurityCtx.Capabilities == nil {
-		specSecurityCtx.Capabilities = &v1.Capabilities{}
-	}
-	hasCapabilitySysResource := false
-	for _, c := range specSecurityCtx.Capabilities.Add {
-		if c == capabilitySysResource {
-			hasCapabilitySysResource = true
-			break
+		specSecurityCtx = &v1.SecurityContext{
+			Capabilities: &v1.Capabilities{
+				Add: []v1.Capability{capabilitySysResource},
+			},
 		}
-	}
-	if !hasCapabilitySysResource {
-		specSecurityCtx.Capabilities.Add =
-			append(specSecurityCtx.Capabilities.Add, capabilitySysResource)
 	}
 
 	return &appsv1.StatefulSet{

--- a/pkg/k8sops/statefulset.go
+++ b/pkg/k8sops/statefulset.go
@@ -98,6 +98,9 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 	// Add SYS_RESOURCE security capability if not set (required to raise
 	// rlimit nofile from the process in container)
 	specSecurityCtx := cluster.Spec.SecurityContext
+	if specSecurityCtx == nil {
+		specSecurityCtx = &v1.SecurityContext{}
+	}
 	if specSecurityCtx.Capabilities == nil {
 		specSecurityCtx.Capabilities = &v1.Capabilities{}
 	}

--- a/pkg/k8sops/statefulset.go
+++ b/pkg/k8sops/statefulset.go
@@ -39,6 +39,7 @@ import (
 const (
 	podIdentityVolumePath = "/etc/m3db/pod-identity"
 	podIdentityVolumeName = "pod-identity"
+	capabilitySysResource = v1.Capability("SYS_RESOURCE")
 )
 
 var (
@@ -94,6 +95,24 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 		},
 	}
 
+	// Add SYS_RESOURCE security capability if not set (required to raise
+	// rlimit nofile from the process in container)
+	specSecurityCtx := cluster.Spec.SecurityContext
+	if specSecurityCtx.Capabilities == nil {
+		specSecurityCtx.Capabilities = &v1.Capabilities{}
+	}
+	hasCapabilitySysResource := false
+	for _, c := range specSecurityCtx.Capabilities.Add {
+		if c == capabilitySysResource {
+			hasCapabilitySysResource = true
+			break
+		}
+	}
+	if !hasCapabilitySysResource {
+		specSecurityCtx.Capabilities.Add =
+			append(specSecurityCtx.Capabilities.Add, capabilitySysResource)
+	}
+
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        ssName,
@@ -117,7 +136,7 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 					Containers: []v1.Container{
 						{
 							Name:            ssName,
-							SecurityContext: cluster.Spec.SecurityContext,
+							SecurityContext: specSecurityCtx,
 							ReadinessProbe:  probeReady,
 							LivenessProbe:   probeHealth,
 							Command: []string{

--- a/tools.json
+++ b/tools.json
@@ -35,6 +35,10 @@
     {
       "Repository": "github.com/kubernetes/kube-openapi/cmd/openapi-gen",
       "Commit": "b52b5b0f5a7c473a00ca5580c49c83449146ac17"
+    },
+    {
+      "Repository": "github.com/axw/gocov",
+      "Commit": "b6eca663ebb7e7ef9798914d19f53ba2c6f74c96"
     }
   ],
   "RetoolVersion": "1.3.7"


### PR DESCRIPTION
This will add SYS_RESOURCE to the security context if not set to ensure the M3DB image is able to call the `setrlimit` syscall for `RLIMIT_NOFILE` when it needs to raise the hard and soft open FDs limit to the value of `fs.nr_open` when they are not the same.

Fixes #137.