### PR TITLE
[api] use status subresource

### DIFF
--- a/pkg/controller/update_cluster.go
+++ b/pkg/controller/update_cluster.go
@@ -224,10 +224,8 @@ func (c *Controller) setStatusPlacementCreated(cluster *myspec.M3DBCluster) (*my
 		Message:        "Created placement",
 	})
 
-	// TODO(schallert): move to UpdateStatus once 1.10 status subresource is out
-	// of alpha.
 	var err error
-	cluster, err = c.crdClient.OperatorV1alpha1().M3DBClusters(cluster.Namespace).Update(cluster)
+	cluster, err = c.crdClient.OperatorV1alpha1().M3DBClusters(cluster.Namespace).UpdateStatus(cluster)
 	if err != nil {
 		err := fmt.Errorf("error updating cluster placement init status: %v", err)
 		c.logger.Error(err.Error())
@@ -269,7 +267,7 @@ func (c *Controller) setStatus(cluster *myspec.M3DBCluster, condition myspec.Clu
 	cond.Message = message
 	cluster.Status.UpdateCondition(cond)
 
-	return c.crdClient.OperatorV1alpha1().M3DBClusters(cluster.Namespace).Update(cluster)
+	return c.crdClient.OperatorV1alpha1().M3DBClusters(cluster.Namespace).UpdateStatus(cluster)
 }
 
 // Updates the cluster if there had been a condition that a pod was

--- a/pkg/k8sops/generators.go
+++ b/pkg/k8sops/generators.go
@@ -101,6 +101,9 @@ func (k *k8sops) GenerateCRD() *apiextensionsv1beta1.CustomResourceDefinition {
 				Plural: m3dboperator.ResourcePlural,
 				Kind:   m3dboperator.ResourceKind,
 			},
+			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
+				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+			},
 		},
 	}
 }

--- a/pkg/k8sops/generators_test.go
+++ b/pkg/k8sops/generators_test.go
@@ -59,6 +59,9 @@ func TestGenerateCRD(t *testing.T) {
 				Plural: m3dboperator.ResourcePlural,
 				Kind:   m3dboperator.ResourceKind,
 			},
+			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
+				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+			},
 		},
 	}
 


### PR DESCRIPTION
CRD Status subresource became enabled by default in 1.11. It allows us
to only update the status part of a CRD rather than having to update the
entire API object, and will unblock OpenAPI validation errors we get if
sending the entire CRD.

https://v1-12.docs.kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#status-subresource

Fixes #151 