### PR TITLE
[controller] clear data in etcd on cluster delete

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -45,6 +45,7 @@ ClusterSpec defines the desired state for a M3 cluster to be converge to.
 | isolationGroups | IsolationGroups specifies a map of key-value pairs. Defines which isolation groups to deploy persistent volumes for data nodes | [][IsolationGroup](#isolationgroup) | false |
 | namespaces | Namespaces specifies the namespaces this cluster will hold. | [][Namespace](#namespace) | false |
 | etcdEndpoints | EtcdEndpoints defines the etcd endpoints to use for service discovery. Must be set if no custom configmap is defined. If set, etcd endpoints will be templated in to the default configmap template. | []string | false |
+| keepEtcdDataOnDelete | KeepEtcdDataOnDelete determines whether the operator will remove cluster metadata (placement + namespaces) in etcd when the cluster is deleted. Unless true, etcd data will be cleared when the cluster is deleted. | bool | false |
 | configMapName | ConfigMapName specifies the ConfigMap to use for this cluster. If unset a default configmap with template variables for etcd endpoints will be used. See \"Configuring M3DB\" in the docs for more. | *string | false |
 | podIdentityConfig | PodIdentityConfig sets the configuration for pod identity. If unset only pod name and UID will be used. | *PodIdentityConfig | false |
 | containerResources | Resources defines memory / cpu constraints for each container in the cluster. | [corev1.ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#resourcerequirements-v1-core) | false |

--- a/pkg/apis/m3dboperator/v1alpha1/cluster.go
+++ b/pkg/apis/m3dboperator/v1alpha1/cluster.go
@@ -194,6 +194,12 @@ type ClusterSpec struct {
 	// +optional
 	EtcdEndpoints []string `json:"etcdEndpoints,omitempty"`
 
+	// KeepEtcdDataOnDelete determines whether the operator will remove cluster
+	// metadata (placement + namespaces) in etcd when the cluster is deleted.
+	// Unless true, etcd data will be cleared when the cluster is deleted.
+	// +optional
+	KeepEtcdDataOnDelete bool `json:"keepEtcdDataOnDelete,omitempty"`
+
 	// ConfigMapName specifies the ConfigMap to use for this cluster. If unset a
 	// default configmap with template variables for etcd endpoints will be used.
 	// See "Configuring M3DB" in the docs for more.

--- a/pkg/apis/m3dboperator/v1alpha1/openapi_generated.go
+++ b/pkg/apis/m3dboperator/v1alpha1/openapi_generated.go
@@ -400,6 +400,13 @@ func schema_pkg_apis_m3dboperator_v1alpha1_ClusterSpec(ref common.ReferenceCallb
 							},
 						},
 					},
+					"keepEtcdDataOnDelete": {
+						SchemaProps: spec.SchemaProps{
+							Description: "KeepEtcdDataOnDelete determines whether the operator will remove cluster metadata (placement + namespaces) in etcd when the cluster is deleted. Unless true, etcd data will be cleared when the cluster is deleted.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"configMapName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ConfigMapName specifies the ConfigMap to use for this cluster. If unset a default configmap with template variables for etcd endpoints will be used. See \"Configuring M3DB\" in the docs for more.",

--- a/pkg/controller/update_cluster_test.go
+++ b/pkg/controller/update_cluster_test.go
@@ -30,7 +30,9 @@ import (
 	"time"
 
 	myspec "github.com/m3db/m3db-operator/pkg/apis/m3dboperator/v1alpha1"
+	crdfake "github.com/m3db/m3db-operator/pkg/client/clientset/versioned/fake"
 	"github.com/m3db/m3db-operator/pkg/k8sops"
+	"github.com/m3db/m3db-operator/pkg/k8sops/labels"
 	"github.com/m3db/m3db-operator/pkg/k8sops/podidentity"
 	"github.com/m3db/m3db-operator/pkg/m3admin"
 
@@ -51,6 +53,7 @@ import (
 	pkgerrors "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	ktesting "k8s.io/client-go/testing"
 )
 
 type namespaceMatcher struct {
@@ -975,4 +978,157 @@ func TestFindPodToRemove(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, pods[1], pod)
 	assert.Equal(t, pl.Instances()[1], inst)
+}
+
+func TestEtcdFinalizer(t *testing.T) {
+	cluster := getFixture("cluster-3-zones.yaml", t)
+	deps := newTestDeps(t, &testOpts{
+		crdObjects: []runtime.Object{cluster},
+	})
+
+	controller := deps.newController()
+	defer deps.cleanup()
+
+	// Mock the API to return errors so we know we don't hit in in
+	// stringArrayContains checks.
+	returnError := func() {
+		controller.crdClient.(*crdfake.Clientset).PrependReactor("update", "m3dbclusters", func(action ktesting.Action) (bool, runtime.Object, error) {
+			return true, &myspec.M3DBCluster{}, errors.New("test")
+		})
+	}
+
+	noError := func() {
+		controller.crdClient.(*crdfake.Clientset).Fake.ReactionChain = []ktesting.Reactor{}
+	}
+
+	cluster, err := controller.ensureEtcdFinalizer(cluster.DeepCopy())
+	assert.NoError(t, err)
+	assert.True(t, stringArrayContains(cluster.ObjectMeta.Finalizers, labels.EtcdDeletionFinalizer))
+
+	// Flip the API to return errors so we know we don't hit Update() once there's
+	// already a finalizer on the cluster.
+	returnError()
+	_, err = controller.ensureEtcdFinalizer(cluster.DeepCopy())
+	assert.NoError(t, err)
+	_, err = controller.removeEtcdFinalizer(cluster.DeepCopy())
+	assert.EqualError(t, pkgerrors.Cause(err), "test")
+	noError()
+
+	cluster, err = controller.removeEtcdFinalizer(cluster.DeepCopy())
+	assert.NoError(t, err)
+	assert.Empty(t, cluster.Finalizers)
+
+	// API returns errors again and we know we don't hit it once the finalizer is
+	// removed.
+	returnError()
+	_, err = controller.removeEtcdFinalizer(cluster.DeepCopy())
+	assert.NoError(t, err)
+	noError()
+
+	// Ensure we only remove the finalizer we care about.
+	cluster.Finalizers = []string{"foo"}
+	_, err = controller.removeEtcdFinalizer(cluster.DeepCopy())
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"foo"}, cluster.Finalizers)
+}
+
+func TestDeletePlacement(t *testing.T) {
+	cluster := getFixture("cluster-simple.yaml", t)
+
+	deps := newTestDeps(t, &testOpts{
+		crdObjects: []runtime.Object{cluster},
+	})
+	controller := deps.newController()
+	defer deps.cleanup()
+
+	deps.placementClient.EXPECT().Get().Return(nil, errors.New("TEST"))
+	err := controller.deletePlacement(cluster)
+	assert.EqualError(t, pkgerrors.Cause(err), "TEST")
+
+	deps.placementClient.EXPECT().Get().Return(nil, m3admin.ErrNotFound)
+	err = controller.deletePlacement(cluster)
+	assert.NoError(t, err)
+
+	deps.placementClient.EXPECT().Get().Return(placement.NewPlacement(), nil)
+	deps.placementClient.EXPECT().Delete().Return(errors.New("TEST2"))
+	err = controller.deletePlacement(cluster)
+	assert.EqualError(t, pkgerrors.Cause(err), "TEST2")
+
+	deps.placementClient.EXPECT().Get().Return(placement.NewPlacement(), nil)
+	deps.placementClient.EXPECT().Delete().Return(nil)
+	err = controller.deletePlacement(cluster)
+	assert.NoError(t, err)
+}
+
+func TestDeleteAllNamespaces(t *testing.T) {
+	cluster := getFixture("cluster-simple.yaml", t)
+
+	deps := newTestDeps(t, &testOpts{
+		crdObjects: []runtime.Object{cluster},
+	})
+	controller := deps.newController()
+	defer deps.cleanup()
+
+	deps.namespaceClient.EXPECT().List().Return(nil, errors.New("TEST"))
+	err := controller.deleteAllNamespaces(cluster)
+	assert.EqualError(t, pkgerrors.Cause(err), "TEST")
+
+	deps.namespaceClient.EXPECT().List().Return(&admin.NamespaceGetResponse{}, nil)
+	err = controller.deleteAllNamespaces(cluster)
+	assert.EqualError(t, pkgerrors.Cause(err), errNilNamespaceRegistry.Error())
+
+	testResp := &admin.NamespaceGetResponse{
+		Registry: &dbns.Registry{
+			Namespaces: map[string]*dbns.NamespaceOptions{
+				"ns1": nil,
+				"ns2": nil,
+			},
+		},
+	}
+
+	deps.namespaceClient.EXPECT().List().Return(testResp, nil)
+	deps.namespaceClient.EXPECT().Delete("ns1").Return(nil)
+	deps.namespaceClient.EXPECT().Delete("ns2").Return(errors.New("TEST"))
+	err = controller.deleteAllNamespaces(cluster)
+	assert.EqualError(t, pkgerrors.Cause(err), "TEST")
+
+	deps.namespaceClient.EXPECT().List().Return(testResp, nil)
+	deps.namespaceClient.EXPECT().Delete("ns1").Return(nil)
+	deps.namespaceClient.EXPECT().Delete("ns2").Return(nil)
+	err = controller.deleteAllNamespaces(cluster)
+	assert.NoError(t, err)
+}
+
+func TestStringArrayContains(t *testing.T) {
+	tests := []struct {
+		arr   []string
+		s     string
+		found bool
+	}{
+		{
+			arr:   nil,
+			s:     "foo",
+			found: false,
+		},
+		{
+			arr:   []string{},
+			s:     "foo",
+			found: false,
+		},
+		{
+			arr:   []string{"foo", "bar"},
+			s:     "foo",
+			found: true,
+		},
+		{
+			arr:   []string{"foo", "bar"},
+			s:     "baz",
+			found: false,
+		},
+	}
+
+	for _, test := range tests {
+		found := stringArrayContains(test.arr, test.s)
+		assert.Equal(t, test.found, found, "expected to find %s in %v", test.s, test.arr)
+	}
 }

--- a/pkg/k8sops/crd_test.go
+++ b/pkg/k8sops/crd_test.go
@@ -89,7 +89,7 @@ func TestCreateOrUpdateCRD_Err(t *testing.T) {
 			// Must create CRD first to have an error updating it.
 			if test.action == "update" {
 				err := k.CreateOrUpdateCRD(m3dboperator.Name, false)
-			assert.NoError(t, err)
+				assert.NoError(t, err)
 			}
 
 			err := k.CreateOrUpdateCRD(m3dboperator.Name, false)

--- a/pkg/k8sops/labels/labels.go
+++ b/pkg/k8sops/labels/labels.go
@@ -43,6 +43,9 @@ const (
 	ComponentM3DBNode = "m3dbnode"
 	// ComponentCoordinator indicates a component is a coordinator.
 	ComponentCoordinator = "coordinator"
+	// EtcdDeletionFinalizer is the finalizer used to delete cluster data stored
+	// in etcd.
+	EtcdDeletionFinalizer = "operator.m3db.io/etcd-deletion"
 )
 
 // BaseLabels returns the base labels we apply to all objects created by the


### PR DESCRIPTION
Leverage Kubernetes finalizers to block fully deleting the cluster until
we've cleaned up the data (placement + namespace) in etcd.

Fixes #44 