### PR TITLE
Add HTTP JSONPB request method to client and update callers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1035,6 +1035,7 @@
     "github.com/coreos/bbolt",
     "github.com/go-openapi/spec",
     "github.com/gogo/protobuf/jsonpb",
+    "github.com/gogo/protobuf/proto",
     "github.com/golang/mock/gomock",
     "github.com/golang/mock/mockgen",
     "github.com/hashicorp/go-retryablehttp",

--- a/pkg/m3admin/client.go
+++ b/pkg/m3admin/client.go
@@ -60,10 +60,6 @@ type client struct {
 	environment string
 }
 
-type nullLogger struct{}
-
-func (nullLogger) Printf(string, ...interface{}) {}
-
 // NewClient returns a new m3admin client.
 func NewClient(clientOpts ...Option) Client {
 	opts := &options{}
@@ -85,7 +81,7 @@ func NewClient(clientOpts ...Option) Client {
 	}
 
 	// We do our own request logging, silence their logger.
-	client.client.Logger = nullLogger{}
+	client.client.Logger.SetOutput(ioutil.Discard)
 	client.client.ErrorHandler = retryhttp.PassthroughErrorHandler
 
 	return client

--- a/pkg/m3admin/client.go
+++ b/pkg/m3admin/client.go
@@ -85,7 +85,7 @@ func NewClient(clientOpts ...Option) Client {
 	}
 
 	// We do our own request logging, silence their logger.
-	client.client.Logger.SetOutput(ioutil.Discard)
+	client.client.Logger = nullLogger{}
 	client.client.ErrorHandler = retryhttp.PassthroughErrorHandler
 
 	return client

--- a/pkg/m3admin/client.go
+++ b/pkg/m3admin/client.go
@@ -60,6 +60,10 @@ type client struct {
 	environment string
 }
 
+type nullLogger struct{}
+
+func (nullLogger) Printf(string, ...interface{}) {}
+
 // NewClient returns a new m3admin client.
 func NewClient(clientOpts ...Option) Client {
 	opts := &options{}
@@ -81,7 +85,7 @@ func NewClient(clientOpts ...Option) Client {
 	}
 
 	// We do our own request logging, silence their logger.
-	client.client.Logger.SetOutput(ioutil.Discard)
+	client.client.Logger = nullLogger{}
 	client.client.ErrorHandler = retryhttp.PassthroughErrorHandler
 
 	return client

--- a/pkg/m3admin/client.go
+++ b/pkg/m3admin/client.go
@@ -29,6 +29,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 
+	"github.com/gogo/protobuf/proto"
 	retryhttp "github.com/hashicorp/go-retryablehttp"
 	pkgerrors "github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -50,6 +51,7 @@ var (
 // Client is an m3admin client.
 type Client interface {
 	DoHTTPRequest(action, url string, data *bytes.Buffer) (*http.Response, error)
+	DoHTTPJSONPBRequest(action, url string, request, response proto.Message) error
 }
 
 type client struct {
@@ -83,7 +85,7 @@ func NewClient(clientOpts ...Option) Client {
 	}
 
 	// We do our own request logging, silence their logger.
-	client.client.Logger = nullLogger{}
+	client.client.Logger.SetOutput(ioutil.Discard)
 	client.client.ErrorHandler = retryhttp.PassthroughErrorHandler
 
 	return client
@@ -165,6 +167,41 @@ func (c *client) DoHTTPRequest(
 	}
 
 	return nil, pkgerrors.WithMessage(ErrNotOk, errMsg)
+}
+
+// DoHTTPJSONPBRequest is a helper for performing a request and
+// parsing the response as a JSONPB message into the response.
+// Both request and response are optional and can be emitted if
+// not wanting to either send or receive message.
+func (c *client) DoHTTPJSONPBRequest(
+	action, url string,
+	request proto.Message,
+	response proto.Message,
+) error {
+	var data *bytes.Buffer
+	if request != nil {
+		data = bytes.NewBuffer(nil)
+		if err := JSONPBMarshal(data, request); err != nil {
+			return err
+		}
+	}
+
+	r, err := c.DoHTTPRequest(action, url, data)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		ioutil.ReadAll(r.Body)
+		r.Body.Close()
+	}()
+
+	if response == nil {
+		// Discard the body since nothing to decode into.
+		return nil
+	}
+
+	return JSONPBUnmarshal(r.Body, response)
 }
 
 func parseResponseError(r *http.Response) (string, error) {

--- a/pkg/m3admin/client_mock.go
+++ b/pkg/m3admin/client_mock.go
@@ -29,6 +29,7 @@ import (
 	"net/http"
 	"reflect"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/golang/mock/gomock"
 )
 
@@ -68,4 +69,18 @@ func (m *MockClient) DoHTTPRequest(action, url string, data *bytes.Buffer) (*htt
 func (mr *MockClientMockRecorder) DoHTTPRequest(action, url, data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoHTTPRequest", reflect.TypeOf((*MockClient)(nil).DoHTTPRequest), action, url, data)
+}
+
+// DoHTTPJSONPBRequest mocks base method
+func (m *MockClient) DoHTTPJSONPBRequest(action, url string, request, response proto.Message) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DoHTTPJSONPBRequest", action, url, request, response)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DoHTTPJSONPBRequest indicates an expected call of DoHTTPJSONPBRequest
+func (mr *MockClientMockRecorder) DoHTTPJSONPBRequest(action, url, request, response interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoHTTPJSONPBRequest", reflect.TypeOf((*MockClient)(nil).DoHTTPJSONPBRequest), action, url, request, response)
 }

--- a/pkg/m3admin/jsonpb.go
+++ b/pkg/m3admin/jsonpb.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/pkg/m3admin/jsonpb.go
+++ b/pkg/m3admin/jsonpb.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package m3admin
+
+import (
+	"io"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+)
+
+// JSONPBUnmarshal unmarshals a JSON protobuf message, allowing
+// for backwards compatible changes by allowing unknown fields to
+// exist when unmarshalling response (new fields will get added
+// and need to be able to be unmarshalled by an old operator
+// calling endpoints on a new coordinator or DB node).
+func JSONPBUnmarshal(r io.Reader, msg proto.Message) error {
+	unmarshaller := &jsonpb.Unmarshaler{AllowUnknownFields: true}
+	return unmarshaller.Unmarshal(r, msg)
+}
+
+// JSONPBMarshal marshals a JSON protobuf message, just using
+// defaults for the marshaller currently.
+func JSONPBMarshal(w io.Writer, msg proto.Message) error {
+	marshaller := &jsonpb.Marshaler{}
+	return marshaller.Marshal(w, msg)
+}

--- a/pkg/m3admin/namespace/client.go
+++ b/pkg/m3admin/namespace/client.go
@@ -126,7 +126,7 @@ func (n *namespaceClient) List() (*admin.NamespaceGetResponse, error) {
 	}
 
 	n.logger.Debug("namespace retrieved")
-	return data, nil
+	return resp, nil
 }
 
 // Delete will delete a namespace

--- a/pkg/m3admin/placement/client.go
+++ b/pkg/m3admin/placement/client.go
@@ -99,7 +99,7 @@ func (p *placementClient) Get() (m3placement.Placement, error) {
 	if resp.Placement == nil {
 		return nil, errors.New("nil placement fetch")
 	}
-	p.logger.Info("placement retreived")
+	p.logger.Debug("placement retrieved")
 	return m3placement.NewPlacementFromProto(resp.Placement)
 }
 


### PR DESCRIPTION
This makes sure that every call site is using the correct JSON marshal/unmarshal and adds helpers so future methods don't have to construct the marshaller themselves and just directly call the `DoHTTPJSONPBRequest` helper.