### PR TITLE
Add patch permission to m3db-operator CR

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -30,7 +30,7 @@ rules:
   verbs: ["create", "get", "deletecollection", "delete"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["list", "get", "watch", "update"]
+  verbs: ["list", "get", "watch", "update", "patch"]
 - apiGroups: ["apps"]
   resources: ["statefulsets", "deployments"]
   verbs: ["*"]

--- a/helm/m3db-operator/templates/cluster_role.yaml
+++ b/helm/m3db-operator/templates/cluster_role.yaml
@@ -20,7 +20,7 @@ rules:
   verbs: ["create", "get", "deletecollection", "delete"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["list", "get", "watch", "update"]
+  verbs: ["list", "get", "watch", "update", "patch"]
 - apiGroups: ["apps"]
   resources: ["statefulsets", "deployments"]
   verbs: ["*"]


### PR DESCRIPTION
Add `patch` permission on `pods`, according to https://github.com/m3db/m3db-operator/issues/168.

Might also need to regenerate bundle and remove `update` now that it's replaced by `patch`?