### PR TITLE
[ci] Run e2e integration tests in Kind

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# If there was a kind cluster created during CI, tear it down.
+KIND="$HOME/bin/kind"
+if [[ -f "$KIND" ]]; then
+  echo "--- :kubernetes: deleting kind cluster"
+    $KIND get clusters -q | while read -r CLUSTER; do
+    $KIND delete cluster --name "$CLUSTER"
+  done
+fi
+
+echo "--- :git: cleaning checkout"
+git clean -dffx

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,12 +27,13 @@ steps:
         config: .buildkite/docker-compose.yml
         workdir: /go/src/github.com/m3db/m3db-operator
     <<: *common
-  - name: ":kubernetes: e2e tests"
-    command: make clean test-e2e
-    env:
-      CGO_ENABLED: 0
-      GIMME_GO_VERSION: 1.13.x
-    plugins:
-      gopath-checkout#v1.0.1:
-        import: github.com/m3db/m3db-operator
-    <<: *common
+  # NB(schallert): skipped until OSS CI stack upgraded
+  # - name: ":kubernetes: e2e tests"
+  #   command: make clean test-e2e
+  #   env:
+  #     CGO_ENABLED: 0
+  #     GIMME_GO_VERSION: 1.13.x
+  #   plugins:
+  #     gopath-checkout#v1.0.1:
+  #       import: github.com/m3db/m3db-operator
+  #   <<: *common

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,3 +27,12 @@ steps:
         config: .buildkite/docker-compose.yml
         workdir: /go/src/github.com/m3db/m3db-operator
     <<: *common
+  - name: ":kubernetes: e2e tests"
+    command: make clean test-e2e
+    env:
+      CGO_ENABLED: 0
+      GIMME_GO_VERSION: 1.13.x
+    plugins:
+      gopath-checkout#v1.0.1:
+        import: github.com/m3db/m3db-operator
+    <<: *common

--- a/Makefile
+++ b/Makefile
@@ -120,10 +120,15 @@ test-no-deps: test-base
 	@echo "--- $@"
 	@$(tools_bin_path)/gocov convert $(coverfile) | $(tools_bin_path)/gocov report
 
+.PHONY: kind-create-cluster
+kind-create-cluster:
+	@echo "--- Starting KIND cluster"
+	@./scripts/kind-create-cluster.sh
+
 .PHONY: test-e2e
-test-e2e:
+test-e2e: kind-create-cluster
 	@echo "--- $@"
-	$(SELF_DIR)/scripts/run_e2e_tests.sh
+	PATH=$(HOME)/bin:$(PATH) $(SELF_DIR)/scripts/run_e2e_tests.sh
 
 .PHONY: testhtml
 testhtml: test-base

--- a/integration/harness/harness.go
+++ b/integration/harness/harness.go
@@ -134,7 +134,7 @@ func (h *Harness) createNamespace(ns string) error {
 	}
 
 	h.Logger.Info("creating namespace", zap.String("namespace", ns))
-	_, err := h.KubeClient.Core().Namespaces().Create(&corev1.Namespace{
+	_, err := h.KubeClient.CoreV1().Namespaces().Create(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ns,
 		},

--- a/integration/manifests/operator.yaml
+++ b/integration/manifests/operator.yaml
@@ -26,7 +26,7 @@ rules:
   verbs: ["create", "get", "deletecollection", "delete"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["list", "get", "watch", "update"]
+  verbs: ["list", "get", "watch", "update", "patch"]
 - apiGroups: ["apps"]
   resources: ["statefulsets", "deployments"]
   verbs: ["*"]
@@ -68,8 +68,12 @@ spec:
       labels:
         name: m3db-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
       containers:
         - name: m3db-operator
-          image: quay.io/m3db/m3db-operator:latest
-          imagePullPolicy: Always
+          image: m3db-operator-kind
+          imagePullPolicy: Never
       serviceAccount: operator-test-sa

--- a/scripts/kind-create-cluster.sh
+++ b/scripts/kind-create-cluster.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -exo pipefail
+
+echo "--- :kubernetes: Installing kind"
+
+KUBE_VERSION=${KUBE_VERSION:-v1.15.7}
+CLUSTER_NAME=kind
+L_UNAME=$(uname | tr "[:upper:]" "[:lower:]")
+
+mkdir -p "$HOME/bin"
+
+if [[ ! -x "$HOME/bin/kind" || "$BUILDKITE" == "true" ]]; then
+  curl -sL -o "$HOME/bin/kind" "https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-${L_UNAME}-amd64"
+fi
+
+if [[ ! -x "$HOME/bin/kubectl" || "$BUILDKITE" == "true" ]]; then
+  curl -sL -o "$HOME/bin/kubectl" "https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/${L_UNAME}/amd64/kubectl"
+fi
+
+chmod +x "$HOME/bin/kind" "$HOME/bin/kubectl"
+export PATH="$HOME/bin:$PATH"
+
+echo "--- :kubernetes: Deleting existing kind clusters"
+kind get clusters -q | while read -r CLUSTER; do
+  kind delete cluster --name "$CLUSTER"
+done
+
+echo "--- :kubernetes: Creating kind cluster"
+
+cat > cluster.yaml <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+  kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "failure-domain.beta.kubernetes.io/zone=us-east1-b"
+- role: worker
+  kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "failure-domain.beta.kubernetes.io/zone=us-east1-c"
+- role: worker
+  kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: JoinConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "failure-domain.beta.kubernetes.io/zone=us-east1-d"
+EOF
+
+kind create cluster --image "kindest/node:$KUBE_VERSION" --name "$CLUSTER_NAME" --config cluster.yaml
+
+kubectl get nodes
+kubectl cluster-info
+
+echo "--- :kubernetes: Kind cluster created"
+
+echo "--- Waiting for cluster to be ready"
+while kubectl get nodes | grep -q NotReady; do
+  sleep 5
+done

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -30,7 +30,7 @@ function main() {
   done
 
   # If a kubectl proxy process is running, delete and wait until it's dead
-  if pgrep -fq 'kubectl proxy'; then
+  if pgrep -f 'kubectl proxy'; then
     pkill -f 'kubectl proxy'
     local PROXYCOUNT=0
     while [[ $PROXYCOUNT -lt 10 ]]; do
@@ -45,6 +45,11 @@ function main() {
   fi
 
   trap cleanup EXIT
+
+  if [[ -z "$SKIP_DOCKER_BUILD" ]]; then
+    docker build -t m3db-operator-kind .
+    kind load docker-image m3db-operator-kind
+  fi
 
   kubectl proxy &
   go clean -testcache


### PR DESCRIPTION
**NOTE:** This can't progress until Uber's OSS Buildkite stack is upgraded. We seem to be hitting a Docker bug or similar issue that poisons the hosts. Does not appear to happen in other newer Buildkite stacks. Commenting out of default BK pipeline for now to allow others to still run the integration tests.