### PR TITLE
[ci] Ensure integration tests always compile

### DIFF
--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -7,4 +7,4 @@ export PACKAGE=github.com/m3db/m3db-operator
 echo "--- :git: Updating git submodules"
 git submodule update --init --recursive
 echo "--- Running unit tests"
-make clean-all test-ci-unit lint metalint bins test-all-gen
+make clean-all test-ci-unit lint metalint bins test-all-gen build-integration

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,11 @@ $(foreach CMD,$(CMDS),$(eval $(CMD_RULES)))
 bins: $(CMDS)
 bins-no-deps: $(foreach CMD,$(CMDS),$(CMD)-no-deps)
 
+# Target to make sure integration tests build even if we're not running them.
+.PHONY: build-integration
+build-integration:
+	go build -tags integration ./integration/...
+
 .PHONY: lint
 lint: install-tools
 	@echo "--- $@"

--- a/integration/harness/harness.go
+++ b/integration/harness/harness.go
@@ -134,7 +134,7 @@ func (h *Harness) createNamespace(ns string) error {
 	}
 
 	h.Logger.Info("creating namespace", zap.String("namespace", ns))
-	_, err := h.KubeClient.Core().Namespaces().Create(&corev1.Namespace{
+	_, err := h.KubeClient.CoreV1().Namespaces().Create(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ns,
 		},

--- a/integration/harness/m3admin.go
+++ b/integration/harness/m3admin.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 
 	myspec "github.com/m3db/m3db-operator/pkg/apis/m3dboperator/v1alpha1"
+	"github.com/m3db/m3db-operator/pkg/k8sops"
 	"github.com/m3db/m3db-operator/pkg/k8sops/m3db"
 	"github.com/m3db/m3db-operator/pkg/m3admin"
 	"github.com/m3db/m3db-operator/pkg/m3admin/placement"
@@ -38,7 +39,7 @@ func (h *Harness) NewPlacementClient(cluster *myspec.M3DBCluster) (placement.Cli
 		return nil, err
 	}
 
-	env := m3db.DefaultM3ClusterEnvironmentName(cluster)
+	env := k8sops.DefaultM3ClusterEnvironmentName(cluster)
 	adminCl := m3admin.NewClient(
 		m3admin.WithEnvironment(env),
 	)


### PR DESCRIPTION
We might not be running them, but want to ensure the test code itself
still compiles.