### PR TITLE
Apply annotations to pods in created StatefulSets

### DIFF
--- a/pkg/k8sops/m3db/generators_test.go
+++ b/pkg/k8sops/m3db/generators_test.go
@@ -37,8 +37,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	crdutils "github.com/ant31/crd-validation/pkg"
-	"k8s.io/utils/pointer"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 )
 
 func TestGenerateCRD(t *testing.T) {
@@ -139,7 +139,8 @@ func TestGenerateStatefulSet(t *testing.T) {
 			Replicas: instanceAmount,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels:      labels,
+					Annotations: annotations.BaseAnnotations(fixture),
 				},
 				Spec: v1.PodSpec{
 					PriorityClassName: "m3db-priority",

--- a/pkg/k8sops/m3db/generators_test.go
+++ b/pkg/k8sops/m3db/generators_test.go
@@ -35,10 +35,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 
 	crdutils "github.com/ant31/crd-validation/pkg"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/utils/pointer"
 )
 
 func TestGenerateCRD(t *testing.T) {

--- a/pkg/k8sops/m3db/generators_test.go
+++ b/pkg/k8sops/m3db/generators_test.go
@@ -39,7 +39,6 @@ import (
 
 	crdutils "github.com/ant31/crd-validation/pkg"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/utils/pointer"
 )
 
 func TestGenerateCRD(t *testing.T) {

--- a/pkg/k8sops/m3db/statefulset.go
+++ b/pkg/k8sops/m3db/statefulset.go
@@ -118,7 +118,8 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 			Replicas: &ic,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: objLabels,
+					Labels:      objLabels,
+					Annotations: objAnnotations,
 				},
 				Spec: v1.PodSpec{
 					PriorityClassName: cluster.Spec.PriorityClassName,


### PR DESCRIPTION
The StatefulSet template was not applying annotations to pods since it was not part of the pod template. This adds the same annotations to the pod.