### PR TITLE
[generators] Expose m3cluster env in pod spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/briandowns/spinner v1.8.0 // indirect
 	github.com/cheekybits/genny v1.0.0 // indirect
 	github.com/cirocosta/grafana-sync v0.0.0-20181123215626-6cbb4a9501c1
+	github.com/d4l3k/messagediff v1.2.1
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/fortytw2/leaktest v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/d4l3k/messagediff v1.2.1 h1:ZcAIMYsUg0EAp9X+tt8/enBE/Q8Yd5kzPynLyKptt9U=
+github.com/d4l3k/messagediff v1.2.1/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkEQxENCrlLo=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/pkg/k8sops/m3db/generators.go
+++ b/pkg/k8sops/m3db/generators.go
@@ -188,7 +188,7 @@ func GenerateStatefulSet(
 
 	if cluster.Spec.EnvVars != nil && len(cluster.Spec.EnvVars) > 0 {
 		cluster := cluster.DeepCopy()
-		m3dbContainer.Env = cluster.Spec.EnvVars
+		m3dbContainer.Env = append(m3dbContainer.Env, cluster.Spec.EnvVars...)
 	}
 
 	return statefulSet, nil

--- a/pkg/k8sops/m3db/generators_test.go
+++ b/pkg/k8sops/m3db/generators_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	crdutils "github.com/ant31/crd-validation/pkg"
+	"github.com/d4l3k/messagediff"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/pointer"
 )
@@ -192,6 +193,10 @@ func TestGenerateStatefulSet(t *testing.T) {
 										},
 									},
 								},
+								{
+									Name:  "M3CLUSTER_ENVIRONMENT",
+									Value: "foo/m3db-cluster",
+								},
 							},
 							Ports: generateContainerPorts(fixture),
 							VolumeMounts: []v1.VolumeMount{
@@ -293,7 +298,10 @@ func TestGenerateStatefulSet(t *testing.T) {
 	newSS, err := GenerateStatefulSet(fixture, isolationGroup, *instanceAmount)
 	assert.NoError(t, err)
 	assert.NotNil(t, newSS)
-	assert.Equal(t, ss, newSS)
+	if !assert.Equal(t, ss, newSS) {
+		diff, _ := messagediff.PrettyDiff(ss, newSS)
+		t.Log(diff)
+	}
 
 	// Reset spec and fixture, test custom config map
 	ss = baseSS.DeepCopy()
@@ -303,7 +311,10 @@ func TestGenerateStatefulSet(t *testing.T) {
 	newSS, err = GenerateStatefulSet(fixture, isolationGroup, *instanceAmount)
 	assert.NoError(t, err)
 	assert.NotNil(t, newSS)
-	assert.Equal(t, ss, newSS)
+	if !assert.Equal(t, ss, newSS) {
+		diff, _ := messagediff.PrettyDiff(ss, newSS)
+		t.Log(diff)
+	}
 
 	// Reset spec and fixture, test custom volume claims
 	ss = baseSS.DeepCopy()
@@ -320,7 +331,10 @@ func TestGenerateStatefulSet(t *testing.T) {
 	newSS, err = GenerateStatefulSet(fixture, isolationGroup, *instanceAmount)
 	assert.NoError(t, err)
 	assert.NotNil(t, newSS)
-	assert.Equal(t, ss, newSS)
+	if !assert.Equal(t, ss, newSS) {
+		diff, _ := messagediff.PrettyDiff(ss, newSS)
+		t.Log(diff)
+	}
 
 	// Reset spec and fixture, test per-isogroup storageclasses
 	ss = baseSS.DeepCopy()
@@ -331,7 +345,10 @@ func TestGenerateStatefulSet(t *testing.T) {
 	newSS, err = GenerateStatefulSet(fixture, isolationGroup, *instanceAmount)
 	assert.NoError(t, err)
 	assert.NotNil(t, newSS)
-	assert.Equal(t, ss, newSS)
+	if !assert.Equal(t, ss, newSS) {
+		diff, _ := messagediff.PrettyDiff(ss, newSS)
+		t.Log(diff)
+	}
 
 	// Ensure changing another isogroup doesn't affect this statefulset
 	ss = baseSS.DeepCopy()
@@ -341,7 +358,10 @@ func TestGenerateStatefulSet(t *testing.T) {
 	newSS, err = GenerateStatefulSet(fixture, isolationGroup, *instanceAmount)
 	assert.NoError(t, err)
 	assert.NotNil(t, newSS)
-	assert.Equal(t, ss, newSS)
+	if !assert.Equal(t, ss, newSS) {
+		diff, _ := messagediff.PrettyDiff(ss, newSS)
+		t.Log(diff)
+	}
 
 	// Test empty tolerations
 	ss = baseSS.DeepCopy()
@@ -352,7 +372,10 @@ func TestGenerateStatefulSet(t *testing.T) {
 	newSS, err = GenerateStatefulSet(fixture, isolationGroup, *instanceAmount)
 	assert.NoError(t, err)
 	assert.NotNil(t, newSS)
-	assert.Equal(t, ss, newSS)
+	if !assert.Equal(t, ss, newSS) {
+		diff, _ := messagediff.PrettyDiff(ss, newSS)
+		t.Log(diff)
+	}
 
 	// Make sure nil security context adds one with SYS_RESOURCE
 	ss = baseSS.DeepCopy()
@@ -367,11 +390,26 @@ func TestGenerateStatefulSet(t *testing.T) {
 	newSS, err = GenerateStatefulSet(fixture, isolationGroup, *instanceAmount)
 	assert.NoError(t, err)
 	assert.NotNil(t, newSS)
-	assert.Equal(t, ss, newSS)
+	if !assert.Equal(t, ss, newSS) {
+		diff, _ := messagediff.PrettyDiff(ss, newSS)
+		t.Log(diff)
+	}
 
 	// Test custom env vars
 	ss = baseSS.DeepCopy()
 	ss.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{
+		{
+			Name: "NAMESPACE",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
+				},
+			},
+		},
+		{
+			Name:  "M3CLUSTER_ENVIRONMENT",
+			Value: "foo/m3db-cluster",
+		},
 		{
 			Name:  "test",
 			Value: "testval",
@@ -408,7 +446,10 @@ func TestGenerateStatefulSet(t *testing.T) {
 	newSS, err = GenerateStatefulSet(fixture, isolationGroup, *instanceAmount)
 	assert.NoError(t, err)
 	assert.NotNil(t, newSS)
-	assert.Equal(t, ss, newSS)
+	if !assert.Equal(t, ss, newSS) {
+		diff, _ := messagediff.PrettyDiff(ss, newSS)
+		t.Log(diff)
+	}
 }
 
 func TestGenerateM3DBService(t *testing.T) {

--- a/pkg/k8sops/m3db/statefulset.go
+++ b/pkg/k8sops/m3db/statefulset.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 
 	myspec "github.com/m3db/m3db-operator/pkg/apis/m3dboperator/v1alpha1"
+	"github.com/m3db/m3db-operator/pkg/k8sops"
 	"github.com/m3db/m3db-operator/pkg/k8sops/annotations"
 	"github.com/m3db/m3db-operator/pkg/k8sops/labels"
 	"github.com/m3db/m3db-operator/pkg/k8sops/podidentity"
@@ -104,77 +105,85 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 		}
 	}
 
+	m3dbContainer := v1.Container{
+		Name:            ssName,
+		SecurityContext: specSecurityCtx,
+		ReadinessProbe:  probeReady,
+		LivenessProbe:   probeHealth,
+		Command: []string{
+			"m3dbnode",
+		},
+		Args: []string{
+			"-f",
+			_configurationFileLocation,
+		},
+		Image:           image,
+		ImagePullPolicy: "Always",
+		Env: []v1.EnvVar{
+			{
+				Name: "NAMESPACE",
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						FieldPath: "metadata.namespace",
+					},
+				},
+			},
+			{
+				Name:  "M3CLUSTER_ENVIRONMENT",
+				Value: k8sops.DefaultM3ClusterEnvironmentName(cluster),
+			},
+		},
+		Ports: nil,
+		VolumeMounts: []v1.VolumeMount{
+			{
+				Name:      _dataVolumeName,
+				MountPath: _dataDirectory,
+			},
+			{
+				Name:      "cache",
+				MountPath: "/var/lib/m3kv/",
+			},
+			generateDownwardAPIVolumeMount(),
+		},
+	}
+
+	stsSpec := appsv1.StatefulSetSpec{
+		ServiceName: HeadlessServiceName(clusterName),
+		Selector: &metav1.LabelSelector{
+			MatchLabels: objLabels,
+		},
+		Replicas: &ic,
+		Template: v1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: objLabels,
+			},
+			Spec: v1.PodSpec{
+				PriorityClassName: cluster.Spec.PriorityClassName,
+				SecurityContext:   cluster.Spec.PodSecurityContext,
+				ImagePullSecrets:  cluster.Spec.ImagePullSecrets,
+				Containers: []v1.Container{
+					m3dbContainer,
+				},
+				Volumes: []v1.Volume{
+					{
+						Name: "cache",
+						VolumeSource: v1.VolumeSource{
+							EmptyDir: &v1.EmptyDirVolumeSource{},
+						},
+					},
+					generateDownwardAPIVolume(),
+				},
+			},
+		},
+	}
+
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        ssName,
 			Labels:      objLabels,
 			Annotations: objAnnotations,
 		},
-		Spec: appsv1.StatefulSetSpec{
-			ServiceName: HeadlessServiceName(clusterName),
-			Selector: &metav1.LabelSelector{
-				MatchLabels: objLabels,
-			},
-			Replicas: &ic,
-			Template: v1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: objLabels,
-				},
-				Spec: v1.PodSpec{
-					PriorityClassName: cluster.Spec.PriorityClassName,
-					SecurityContext:   cluster.Spec.PodSecurityContext,
-					ImagePullSecrets:  cluster.Spec.ImagePullSecrets,
-					Containers: []v1.Container{
-						{
-							Name:            ssName,
-							SecurityContext: specSecurityCtx,
-							ReadinessProbe:  probeReady,
-							LivenessProbe:   probeHealth,
-							Command: []string{
-								"m3dbnode",
-							},
-							Args: []string{
-								"-f",
-								_configurationFileLocation,
-							},
-							Image:           image,
-							ImagePullPolicy: "Always",
-							Env: []v1.EnvVar{
-								{
-									Name: "NAMESPACE",
-									ValueFrom: &v1.EnvVarSource{
-										FieldRef: &v1.ObjectFieldSelector{
-											FieldPath: "metadata.namespace",
-										},
-									},
-								},
-							},
-							Ports: nil,
-							VolumeMounts: []v1.VolumeMount{
-								{
-									Name:      _dataVolumeName,
-									MountPath: _dataDirectory,
-								},
-								{
-									Name:      "cache",
-									MountPath: "/var/lib/m3kv/",
-								},
-								generateDownwardAPIVolumeMount(),
-							},
-						},
-					},
-					Volumes: []v1.Volume{
-						{
-							Name: "cache",
-							VolumeSource: v1.VolumeSource{
-								EmptyDir: &v1.EmptyDirVolumeSource{},
-							},
-						},
-						generateDownwardAPIVolume(),
-					},
-				},
-			},
-		},
+		Spec: stsSpec,
 	}
 }
 


### PR DESCRIPTION
Allows users to reference `${M3CLUSTER_ENVIRONMENT}` in custom
configmaps to reduce boilerplate. Also fixes a bug in container
environment creation that would previously overwrite default environment
variables.