### PR TITLE
[k8sops] Ensure dbnodes in DNS when bootstrapping

### DIFF
--- a/pkg/k8sops/m3db/generators.go
+++ b/pkg/k8sops/m3db/generators.go
@@ -219,6 +219,10 @@ func GenerateM3DBService(cluster *myspec.M3DBCluster) (*v1.Service, error) {
 			Ports:     generateM3DBServicePorts(cluster),
 			ClusterIP: v1.ClusterIPNone,
 			Type:      v1.ServiceTypeClusterIP,
+			// Ensure we still publish dbnode DNS names so that we can look up nodes
+			// while they're bootstrapping. We don't do this for the coordinator
+			// service as we don't want to route unready coordinators.
+			PublishNotReadyAddresses: true,
 		},
 	}, nil
 }

--- a/pkg/k8sops/m3db/generators_test.go
+++ b/pkg/k8sops/m3db/generators_test.go
@@ -495,10 +495,11 @@ func TestGenerateM3DBService(t *testing.T) {
 			},
 		},
 		Spec: v1.ServiceSpec{
-			Selector:  baseLabels,
-			Ports:     generateM3DBServicePorts(cluster),
-			ClusterIP: v1.ClusterIPNone,
-			Type:      v1.ServiceTypeClusterIP,
+			Selector:                 baseLabels,
+			Ports:                    generateM3DBServicePorts(cluster),
+			ClusterIP:                v1.ClusterIPNone,
+			Type:                     v1.ServiceTypeClusterIP,
+			PublishNotReadyAddresses: true,
 		},
 	}
 


### PR DESCRIPTION
By default Kubernetes will not generate DNS names for a pod if it's not
ready. This sets `publishNotReadyAddresses` on the M3DB service so that
we can look up pod IPs even when they're bootstrapping (and thus send
them writes to be buffered to commitlog).