### PR TITLE
tentative support for an external controlling coordinator

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -62,6 +62,7 @@ ClusterSpec defines the desired state for a M3 cluster to be converge to.
 | nodeEndpointFormat | NodeEndpointFormat allows overriding of the endpoint used for a node in the M3DB placement. Defaults to \"{{ .PodName }}.{{ .M3DBService }}:{{ .Port }}\". Useful if access to the cluster from other namespaces is desired. See \"Node Endpoint\" docs for full variables available. | string | false |
 | hostNetwork | HostNetwork indicates whether M3DB pods should run in the same network namespace as the node its on. This option should be used sparingly due to security concerns outlined in the linked documentation. https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces | bool | false |
 | dnsPolicy | DNSPolicy allows the user to set the pod's DNSPolicy. This is often used in conjunction with HostNetwork.+optional | *corev1.DNSPolicy | false |
+| externalCoordinatorSelector | Specify a \"controlling\" coordinator for the cluster It is expected that there is a separate standalone coordinator cluster It is externally managed - not managed by this operator It is expected to have a service endpoint Setup this db cluster, but do not assume a co-located coordinator Instead provide a selector here so we can point to a separate coordinator service Specify here the labels required for the selector | map[string]string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/apis/m3dboperator/v1alpha1/cluster.go
+++ b/pkg/apis/m3dboperator/v1alpha1/cluster.go
@@ -277,6 +277,15 @@ type ClusterSpec struct {
 	// conjunction with HostNetwork.+optional
 	// +optional
 	DNSPolicy *corev1.DNSPolicy `json:"dnsPolicy,omitEmpty"`
+
+	// Specify a "controlling" coordinator for the cluster
+	// It is expected that there is a separate standalone coordinator cluster
+	// It is externally managed - not managed by this operator
+	// It is expected to have a service endpoint
+	// Setup this db cluster, but do not assume a co-located coordinator
+	// Instead provide a selector here so we can point to a separate coordinator service
+	// Specify here the labels required for the selector
+	ExternalCoordinatorSelector map[string]string `json:"externalCoordinatorSelector,omitempty"`
 }
 
 // NodeAffinityTerm represents a node label and a set of label values, any of

--- a/pkg/k8sops/m3db/generators.go
+++ b/pkg/k8sops/m3db/generators.go
@@ -236,6 +236,9 @@ func GenerateCoordinatorService(cluster *myspec.M3DBCluster) (*v1.Service, error
 
 	selectorLabels := labels.BaseLabels(cluster)
 	selectorLabels[labels.Component] = labels.ComponentM3DBNode
+	if len(cluster.Spec.ExternalCoordinatorSelector) > 0 {
+		selectorLabels = cluster.Spec.ExternalCoordinatorSelector
+	}
 
 	serviceLabels := labels.BaseLabels(cluster)
 	serviceLabels[labels.Component] = labels.ComponentCoordinator

--- a/pkg/k8sops/m3db/generators_test.go
+++ b/pkg/k8sops/m3db/generators_test.go
@@ -542,4 +542,10 @@ func TestGenerateCoordinatorService(t *testing.T) {
 	}
 
 	assert.Equal(t, expSvc, svc)
+
+	cluster.Spec.ExternalCoordinatorSelector = map[string]string{"foo": "bar"}
+	expSvc.Spec.Selector = map[string]string{"foo": "bar"}
+	svc, err = GenerateCoordinatorService(cluster)
+	assert.NoError(t, err)
+	assert.Equal(t, expSvc, svc)
 }


### PR DESCRIPTION
This allows the operator to startup in db-only mode (no colocated coordinator).  Uses an externally managed coordinator. Start the db with no "coordinator" section in the configmap.

Pass in the labels of the externally controlled coordinator's service endpoint.

`spec:
.
.
.
  externalCoordinatorSelector:
    app: coordinator
.
.
.`

The db-only cluster will boot up using the external coordinator.