### PR TITLE
Added initial support for PodMetaData, handling Annotations only

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -65,6 +65,7 @@ ClusterSpec defines the desired state for a M3 cluster to be converge to.
 | externalCoordinatorSelector | Specify a \"controlling\" coordinator for the cluster It is expected that there is a separate standalone coordinator cluster It is externally managed - not managed by this operator It is expected to have a service endpoint Setup this db cluster, but do not assume a co-located coordinator Instead provide a selector here so we can point to a separate coordinator service Specify here the labels required for the selector | map[string]string | false |
 | initContainers | Custom setup for db nodes can be done via initContainers Provide the complete spec for the initContainer here If any storage volumes are needed in the initContainer see InitVolumes below | []corev1.Container | false |
 | initVolumes | If the InitContainers require any storage volumes Provide the complete specification for the required Volumes here | []corev1.Volume | false |
+| podMetadata | PodMetadata is for any Metadata that is unique to the pods, and does not belong on any other objects, such as Prometheus scrape tags | [metav1.ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#objectmeta-v1-meta) | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/apis/m3dboperator/v1alpha1/cluster.go
+++ b/pkg/apis/m3dboperator/v1alpha1/cluster.go
@@ -295,6 +295,10 @@ type ClusterSpec struct {
 	// If the InitContainers require any storage volumes
 	// Provide the complete specification for the required Volumes here
 	InitVolumes []corev1.Volume `json:"initVolumes,omitempty"`
+
+	// PodMetadata is for any Metadata that is unique to the pods, and does
+	// not belong on any other objects, such as Prometheus scrape tags
+	PodMetadata metav1.ObjectMeta `json:"podMetadata,omitempty"`
 }
 
 // NodeAffinityTerm represents a node label and a set of label values, any of

--- a/pkg/k8sops/annotations/annotations.go
+++ b/pkg/k8sops/annotations/annotations.go
@@ -51,3 +51,17 @@ func BaseAnnotations(cluster *myspec.M3DBCluster) map[string]string {
 
 	return base
 }
+
+// PodAnnotations is for specifying annotations that are only to be
+// applied to the pods such as prometheus scrape tags
+func PodAnnotations(cluster *myspec.M3DBCluster) map[string]string {
+	base := BaseAnnotations(cluster)
+	for k := range cluster.Spec.PodMetadata.Annotations {
+		// accept any user-specified annotations if its safe to do so
+		if _, found := base[k]; !found {
+			base[k] = cluster.Spec.PodMetadata.Annotations[k]
+		}
+	}
+
+	return base
+}

--- a/pkg/k8sops/annotations/annotations_test.go
+++ b/pkg/k8sops/annotations/annotations_test.go
@@ -51,3 +51,34 @@ func TestGenerateBaseAnnotations(t *testing.T) {
 
 	assert.Equal(t, expAnnotations, annotations)
 }
+
+func TestGeneratePodAnnotations(t *testing.T) {
+	cluster := &myspec.M3DBCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster-foo",
+		},
+		Spec: myspec.ClusterSpec{
+			PodMetadata: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"pod-annotation": "some-annotation",
+				},
+			},
+		},
+	}
+
+	annotations := PodAnnotations(cluster)
+	expAnnotations := map[string]string{
+		"operator.m3db.io/app":     "m3db",
+		"operator.m3db.io/cluster": "cluster-foo",
+		"pod-annotation":           "some-annotation",
+	}
+
+	assert.Equal(t, expAnnotations, annotations)
+
+	cluster.Spec.Annotations = map[string]string{"foo": "bar"}
+	annotations = PodAnnotations(cluster)
+	expAnnotations["foo"] = "bar"
+	expAnnotations["pod-annotation"] = "some-annotation"
+
+	assert.Equal(t, expAnnotations, annotations)
+}

--- a/pkg/k8sops/m3db/generators_test.go
+++ b/pkg/k8sops/m3db/generators_test.go
@@ -488,6 +488,28 @@ func TestGenerateStatefulSet(t *testing.T) {
 		diff, _ := messagediff.PrettyDiff(ss, newSS)
 		t.Log(diff)
 	}
+
+	// Test init containers
+	fixture = getFixture("testM3DBCluster.yaml", t)
+	fixture.Spec.InitContainers = []v1.Container{
+		{
+			Name: "init0",
+		},
+	}
+
+	ss = baseSS.DeepCopy()
+	ss.Spec.Template.Spec.InitContainers = []v1.Container{
+		{
+			Name: "init0",
+		},
+	}
+	newSS, err = GenerateStatefulSet(fixture, isolationGroup, *instanceAmount)
+	assert.NoError(t, err)
+	assert.NotNil(t, newSS)
+	if !assert.Equal(t, ss, newSS) {
+		diff, _ := messagediff.PrettyDiff(ss, newSS)
+		t.Log(diff)
+	}
 }
 
 func TestGenerateM3DBService(t *testing.T) {
@@ -525,6 +547,12 @@ func TestGenerateM3DBService(t *testing.T) {
 		},
 	}
 
+	assert.Equal(t, expSvc, svc)
+
+	cluster.Spec.ExternalCoordinatorSelector = map[string]string{"foo": "bar"}
+	expSvc.Spec.Selector = map[string]string{"foo": "bar"}
+	svc, err = GenerateCoordinatorService(cluster)
+	assert.NoError(t, err)
 	assert.Equal(t, expSvc, svc)
 }
 

--- a/pkg/k8sops/m3db/generators_test.go
+++ b/pkg/k8sops/m3db/generators_test.go
@@ -548,12 +548,6 @@ func TestGenerateM3DBService(t *testing.T) {
 	}
 
 	assert.Equal(t, expSvc, svc)
-
-	cluster.Spec.ExternalCoordinatorSelector = map[string]string{"foo": "bar"}
-	expSvc.Spec.Selector = map[string]string{"foo": "bar"}
-	svc, err = GenerateCoordinatorService(cluster)
-	assert.NoError(t, err)
-	assert.Equal(t, expSvc, svc)
 }
 
 func TestGenerateCoordinatorService(t *testing.T) {

--- a/pkg/k8sops/m3db/generators_test.go
+++ b/pkg/k8sops/m3db/generators_test.go
@@ -488,28 +488,6 @@ func TestGenerateStatefulSet(t *testing.T) {
 		diff, _ := messagediff.PrettyDiff(ss, newSS)
 		t.Log(diff)
 	}
-
-	// Test init containers
-	fixture = getFixture("testM3DBCluster.yaml", t)
-	fixture.Spec.InitContainers = []v1.Container{
-		{
-			Name: "init0",
-		},
-	}
-
-	ss = baseSS.DeepCopy()
-	ss.Spec.Template.Spec.InitContainers = []v1.Container{
-		{
-			Name: "init0",
-		},
-	}
-	newSS, err = GenerateStatefulSet(fixture, isolationGroup, *instanceAmount)
-	assert.NoError(t, err)
-	assert.NotNil(t, newSS)
-	if !assert.Equal(t, ss, newSS) {
-		diff, _ := messagediff.PrettyDiff(ss, newSS)
-		t.Log(diff)
-	}
 }
 
 func TestGenerateM3DBService(t *testing.T) {

--- a/pkg/k8sops/m3db/statefulset.go
+++ b/pkg/k8sops/m3db/statefulset.go
@@ -63,7 +63,7 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 		objLabels[k] = v
 	}
 
-	objAnnotations := annotations.BaseAnnotations(cluster)
+	objAnnotations := annotations.PodAnnotations(cluster)
 
 	// TODO(schallert): we're currently using the health of the coordinator for
 	// liveness probes until https://github.com/m3db/m3/issues/996 is fixed. Move


### PR DESCRIPTION
The general Annotations in the ClusterSpec get applied to both the Services and the Pods.  There are cases where the user wants annotation exclusively for the Pod, such as when marking a Pod to be scraped by Prometheus.  This PR puts in an ObjectMeta at the PodMetadata metav1.ClusterSpec level to facilitate specifying Pod-only Metadata.  I've only implemented Annotations.  I've added a test case for the Pod-only annotations.
