### PR TITLE
[controller] Don't update Status if noop

### DIFF
--- a/pkg/controller/update_cluster.go
+++ b/pkg/controller/update_cluster.go
@@ -257,6 +257,14 @@ func (c *M3DBController) setStatus(cluster *myspec.M3DBCluster, condition myspec
 		}
 	}
 
+	if ok && cond.Status == status {
+		c.logger.Debug("conditions equal, nothing to do",
+			zap.String("condition", string(condition)),
+			zap.String("status", string(status)),
+		)
+		return cluster, nil
+	}
+
 	curTime := c.clock.Now().UTC().Format(time.RFC3339)
 	if cond.Status != status {
 		cond.LastTransitionTime = curTime


### PR DESCRIPTION
The current logic causes some Statuses to get updated even if they
haven't changed. This causes an update storm, where updating the status
causes the cluster to be re-enqueued for processing and then have its
status updated again. This puts unnecessary load on the API server and
operator.