### PR TITLE
[controller] Only list objects created by operator

### DIFF
--- a/cmd/m3db-operator/main.go
+++ b/cmd/m3db-operator/main.go
@@ -174,7 +174,7 @@ func main() {
 
 	labelReq, err := klabels.NewRequirement(labels.App, selection.Exists, nil)
 	if err != nil {
-		logger.Fatal("failed to construct pod selector requirement", zap.Error(err))
+		logger.Fatal("failed to construct selector requirement", zap.Error(err))
 	}
 	tweakOpts := kubeinformers.WithTweakListOptions(func(opts *metav1.ListOptions) {
 		// PodSelector provides a selector for listing only M3DB pods to annotate.
@@ -187,7 +187,7 @@ func main() {
 		// filteredInformerFactory is used to create the pod and statefulset
 		// informers. We know that every pod and StatefulSet created by the operator
 		// will have its hardcoded labels. The pod annotation and statefulset loop
-		// may slow down in clusters with many pods or statefulset if it must
+		// may slow down in clusters with many pods or statefulsets if it must
 		// process every objects in the cluster. The filter only lists objects that
 		// have labels we expect.
 		filteredInformerFactory kubeinformers.SharedInformerFactory

--- a/cmd/m3db-operator/main.go
+++ b/cmd/m3db-operator/main.go
@@ -33,12 +33,16 @@ import (
 	clientset "github.com/m3db/m3db-operator/pkg/client/clientset/versioned"
 	informers "github.com/m3db/m3db-operator/pkg/client/informers/externalversions"
 	"github.com/m3db/m3db-operator/pkg/controller"
+	"github.com/m3db/m3db-operator/pkg/k8sops/labels"
 	"github.com/m3db/m3db-operator/pkg/k8sops/m3db"
 	"github.com/m3db/m3db-operator/pkg/k8sops/podidentity"
 
 	"github.com/m3db/m3x/instrument"
 
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -53,7 +57,7 @@ import (
 
 const (
 	// Informers will resync on this interval
-	_informerSyncDuration = time.Minute
+	_informerSyncDuration = 5 * time.Minute
 )
 
 var (
@@ -168,22 +172,41 @@ func main() {
 		logger.Fatal("failed to create k8sclient", zap.Error(err))
 	}
 
-	stopCh := make(chan struct{})
-	var kubeInformerFactory kubeinformers.SharedInformerFactory
+	labelReq, err := klabels.NewRequirement(labels.App, selection.Exists, nil)
+	if err != nil {
+		logger.Fatal("failed to construct pod selector requirement", zap.Error(err))
+	}
+	tweakOpts := kubeinformers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+		// PodSelector provides a selector for listing only M3DB pods to annotate.
+		podSelector := klabels.NewSelector().Add(*labelReq)
+		opts.LabelSelector = podSelector.String()
+	})
+
+	var (
+		m3dbClusterInformerFactory informers.SharedInformerFactory
+		// filteredInformerFactory is used to create the pod and statefulset
+		// informers. We know that every pod and StatefulSet created by the operator
+		// will have its hardcoded labels. The pod annotation and statefulset loop
+		// may slow down in clusters with many pods or statefulset if it must
+		// process every objects in the cluster. The filter only lists objects that
+		// have labels we expect.
+		filteredInformerFactory kubeinformers.SharedInformerFactory
+		// The kube informer factory is still required to list nodes, as they don't
+		// have our label.
+		kubeInformerFactory kubeinformers.SharedInformerFactory
+	)
+
 	if _namespace == "all" {
 		kubeInformerFactory = kubeinformers.NewSharedInformerFactory(kubeClient, _informerSyncDuration)
+		m3dbClusterInformerFactory = informers.NewSharedInformerFactory(crdClient, _informerSyncDuration)
+		filteredInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, _informerSyncDuration, tweakOpts)
 	} else {
 		kubeInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, _informerSyncDuration, kubeinformers.WithNamespace(_namespace))
+		m3dbClusterInformerFactory = informers.NewSharedInformerFactoryWithOptions(crdClient, _informerSyncDuration, informers.WithNamespace(_namespace))
+		filteredInformerFactory = kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, _informerSyncDuration, kubeinformers.WithNamespace(_namespace), tweakOpts)
 	}
 
 	nodeLister := kubeInformerFactory.Core().V1().Nodes().Lister()
-
-	var m3dbClusterInformerFactory informers.SharedInformerFactory
-	if _namespace == "all" {
-		m3dbClusterInformerFactory = informers.NewSharedInformerFactory(crdClient, _informerSyncDuration)
-	} else {
-		m3dbClusterInformerFactory = informers.NewSharedInformerFactoryWithOptions(crdClient, _informerSyncDuration, informers.WithNamespace(_namespace))
-	}
 
 	clusterLogger := logger.With(zap.String("controller", "m3db-cluster-controller"))
 	idLogger := logger.With(zap.String("component", "pod-identity-provider"))
@@ -203,6 +226,7 @@ func main() {
 	opts := []controller.Option{
 		controller.WithConfig(config),
 		controller.WithKubeInformerFactory(kubeInformerFactory),
+		controller.WithFilteredInformerFactory(filteredInformerFactory),
 		controller.WithM3DBClusterInformerFactory(m3dbClusterInformerFactory),
 		controller.WithPodIdentityProvider(idProvider),
 		controller.WithLogger(clusterLogger),
@@ -223,7 +247,9 @@ func main() {
 		logger.Fatal("failed to create controller", zap.Error(err))
 	}
 
+	stopCh := make(chan struct{})
 	go kubeInformerFactory.Start(stopCh)
+	go filteredInformerFactory.Start(stopCh)
 	go m3dbClusterInformerFactory.Start(stopCh)
 
 	// Trap the INT and TERM signals

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -693,7 +693,7 @@ func (c *M3DBController) handleStatefulSetUpdate(obj interface{}) {
 		c.logger.Info("recovered object from tombstone", zap.String("name", object.GetName()))
 	}
 
-	c.logger.Info("processing statefulset", zap.String("name", object.GetName()))
+	c.logger.Info("processing statefulset", zap.String("statefulset.namespace", object.GetNamespace()), zap.String("statefulset.name", object.GetName()))
 
 	owner := metav1.GetControllerOf(object)
 	// TODO(schallert): const
@@ -703,7 +703,7 @@ func (c *M3DBController) handleStatefulSetUpdate(obj interface{}) {
 
 	cluster, err := c.clusterLister.M3DBClusters(object.GetNamespace()).Get(owner.Name)
 	if err != nil {
-		c.logger.Info("ignoring orphaned object", zap.String("m3dbcluster", owner.Name), zap.String("statefulset", object.GetName()))
+		c.logger.Info("ignoring orphaned object", zap.String("m3dbcluster", owner.Name), zap.String("namespace", object.GetNamespace()), zap.String("statefulset", object.GetName()))
 		return
 	}
 
@@ -801,7 +801,7 @@ func (c *M3DBController) handlePodUpdate(pod *corev1.Pod) error {
 		return err
 	}
 
-	podLogger := c.logger.With(zap.String("pod", pod.Name))
+	podLogger := c.logger.With(zap.String("pod.namespace", pod.Namespace), zap.String("pod.name", pod.Name))
 	podLogger.Info("processing pod")
 
 	cluster, err := c.getParentCluster(pod)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -802,7 +802,7 @@ func (c *M3DBController) handlePodUpdate(pod *corev1.Pod) error {
 	}
 
 	podLogger := c.logger.With(zap.String("pod", pod.Name))
-	podLogger.Debug("processing pod")
+	podLogger.Info("processing pod")
 
 	cluster, err := c.getParentCluster(pod)
 	if err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -56,10 +56,10 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	"k8s.io/utils/pointer"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -132,8 +132,6 @@ func NewM3DBController(opts ...Option) (*M3DBController, error) {
 		return nil, err
 	}
 
-	kubeInformerFactory := options.kubeInformerFactory
-	m3dbClusterInformerFactory := options.m3dbClusterInformerFactory
 	kclient := options.kclient
 	kubeClient := options.kubeClient
 	crdClient := options.crdClient
@@ -150,9 +148,9 @@ func NewM3DBController(opts ...Option) (*M3DBController, error) {
 		multiClient.clusterURLFn = clusterURLProxy
 	}
 
-	statefulSetInformer := kubeInformerFactory.Apps().V1().StatefulSets()
-	podInformer := kubeInformerFactory.Core().V1().Pods()
-	m3dbClusterInformer := m3dbClusterInformerFactory.Operator().V1alpha1().M3DBClusters()
+	statefulSetInformer := options.filteredInformerFactory.Apps().V1().StatefulSets()
+	podInformer := options.filteredInformerFactory.Core().V1().Pods()
+	m3dbClusterInformer := options.m3dbClusterInformerFactory.Operator().V1alpha1().M3DBClusters()
 
 	samplescheme.AddToScheme(scheme.Scheme)
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -79,6 +79,7 @@ func TestNew(t *testing.T) {
 		WithCRDClient(crdClient),
 		WithKubeClient(kubeClient),
 		WithKubeInformerFactory(kubeinformers.NewSharedInformerFactory(kubeClient, 0)),
+		WithFilteredInformerFactory(kubeinformers.NewSharedInformerFactory(kubeClient, 0)),
 		WithM3DBClusterInformerFactory(m3dbinformers.NewSharedInformerFactory(crdClient, 0)),
 	}
 

--- a/pkg/controller/options.go
+++ b/pkg/controller/options.go
@@ -49,6 +49,7 @@ type options struct {
 	crdClient                  clientset.Interface
 	kubeClient                 kubernetes.Interface
 	kubeInformerFactory        kubeinformers.SharedInformerFactory
+	filteredInformerFactory    kubeinformers.SharedInformerFactory
 	m3dbClusterInformerFactory informers.SharedInformerFactory
 	kubectlProxy               bool
 }
@@ -98,6 +99,13 @@ func WithKubeClient(cl kubernetes.Interface) Option {
 func WithKubeInformerFactory(f kubeinformers.SharedInformerFactory) Option {
 	return optionFn(func(o *options) {
 		o.kubeInformerFactory = f
+	})
+}
+
+// WithFilteredInformerFactory sets the Filteredrnetes base type informer factory.
+func WithFilteredInformerFactory(f kubeinformers.SharedInformerFactory) Option {
+	return optionFn(func(o *options) {
+		o.filteredInformerFactory = f
 	})
 }
 


### PR DESCRIPTION
Continuously listing every pod and statefulset in large clusters can
slow down the operator control loops significantly. We know every pod
and statefulset created by an M3DBCluster will have predetermined
labels, and can only list objects from the Kubernetes API with those
labels.