### PR TITLE
[controller] Fix bug in TestHandleUpdateClusterCreatesStatefulSets

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -839,7 +839,6 @@ k8s.io/apiextensions-apiserver v0.17.2 h1:cP579D2hSZNuO/rZj9XFRzwJNYb41DbNANJb6K
 k8s.io/apiextensions-apiserver v0.17.2/go.mod h1:4KdMpjkEjjDI2pPfBA15OscyNldHWdBCfsWMDWAmSTs=
 k8s.io/apimachinery v0.17.2 h1:hwDQQFbdRlpnnsR64Asdi55GyCaIP/3WQpMmbNBeWr4=
 k8s.io/apimachinery v0.17.2/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
-k8s.io/apimachinery v0.18.5 h1:Lh6tgsM9FMkC12K5T5QjRm7rDs6aQN5JHkA0JomULDM=
 k8s.io/apiserver v0.17.2/go.mod h1:lBmw/TtQdtxvrTk0e2cgtOxHizXI+d0mmGQURIHQZlo=
 k8s.io/client-go v0.17.2 h1:ndIfkfXEGrNhLIgkr0+qhRguSD3u6DCmonepn1O6NYc=
 k8s.io/client-go v0.17.2/go.mod h1:QAzRgsa0C2xl4/eVpeVAZMvikCn8Nm81yqVx3Kk9XYI=


### PR DESCRIPTION
This commit fixes a bug in the logic of the `TestHandleUpdateClusterCreatesStatefulSets` test. The test checks that the controller creates all the `StatefulSet`'s in a new cluster. Previously, the test checked that all the expected `StatefulSet`'s were created by checking the length of the `map` that the test uses to track `StatefulSet`'s that were created:

```go

expectedMu.Lock()
created := len(expectedSetsCreated)
expectedMu.Unlock()
if created != len(test.expCreateStatefulSets) {
    time.Sleep(100 * time.Millisecond)
    continue
}
done = true
```

However, when the test creates `expectedSetsCreated` it also inserts into it all the `StatefulSet`'s that it expects so the previous `if` condition will always be true:

```go
expectedSetsCreated := make(map[string]bool)
for _, name := range test.expCreateStatefulSets {
    expectedSetsCreated[name] = false
}
```

This commit changes the test so it no longer adds the expected `StatefulSet`'s to `expectedSetsCreated` after it's created, so the subsequent check on the length of `expectedSetsCreated` will be valid because only the `Reactor` function will insert into `expectedSetsCreated`.

After making this change, however, I noticed that the tests were starting to fail. After some debugging, I realized this was because the `Reaction` function was `true`. The [documentation for it states](url):

>  If "handled" is false, then the test client will ignore the results and continue to the next ReactionFunc. 

Since we were returning true, the next function in the chain, which would add it to the "fake" Kubernetes client we're using, never got called, so it would never be returned from subsequent calls to list the `StatefulSet`'s and, as a result, we would continue retrying to create it.

After changing the function to return false, I began encountering one final problem. Occasionally, the call to create a missing `StatefulSet` would return an error because the `StatefulSet` we were trying to create already existed. It seemed this was a caching problem caused when the call to list the `StatefulSet`'s in the cluster didn't return the new `StatefulSet`. To address this problem I updated the error handing after calling `Create` to check if the error was because the `StatefulSet` already exists and to log and return nil if so.