### PR TITLE
[controller] Create constant for annotation value indicating enabled

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -959,7 +959,7 @@ func updatedStatefulSet(
 ) (*appsv1.StatefulSet, bool, error) {
 	// The operator will only perform an update if the current StatefulSet has been
 	// annotated to indicate that it is okay to update it.
-	if val, ok := actual.Annotations[annotations.Update]; !ok || val != "enabled" {
+	if val, ok := actual.Annotations[annotations.Update]; !ok || val != annotations.EnabledVal {
 		return nil, false, nil
 	}
 

--- a/pkg/k8sops/annotations/annotations.go
+++ b/pkg/k8sops/annotations/annotations.go
@@ -37,6 +37,9 @@ const (
 	// Update is the annotation used by the operator to determine if a StatefulSet is
 	// allowed to be updated.
 	Update = "operator.m3db.io/update"
+
+	// EnabledVal is the value that indicates an annotation is enabled.
+	EnabledVal = "enabled"
 )
 
 // BaseAnnotations returns the base annotations we apply to all objects


### PR DESCRIPTION
This commit defines the string that we look for to indicate that an annotation has been enabled (`"enabled"`) as a constant so it can be imported by other packages.