### PR TITLE
[api] Allow setting static external coordinator

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -80,6 +80,7 @@ ExternalCoordinatorConfig defines parameters for using an external coordinator t
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | selector |  | map[string]string | true |
+| serviceEndpoint |  | string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/pkg/apis/m3dboperator/v1alpha1/cluster.go
+++ b/pkg/apis/m3dboperator/v1alpha1/cluster.go
@@ -324,7 +324,8 @@ type ClusterSpec struct {
 // Setup this db cluster, but do not assume a co-located coordinator. Instead
 // provide a selector here so we can point to a separate coordinator service.
 type ExternalCoordinatorConfig struct {
-	Selector map[string]string `json:"selector,omityempty"`
+	Selector        map[string]string `json:"selector,omityempty"`
+	ServiceEndpoint string            `json:"serviceEndpoint,omitempty"`
 }
 
 // NodeAffinityTerm represents a node label and a set of label values, any of

--- a/pkg/controller/m3admin_client_test.go
+++ b/pkg/controller/m3admin_client_test.go
@@ -42,10 +42,10 @@ import (
 
 func newTestAdminClient(cl m3admin.Client, url string) *multiAdminClient {
 	m := newMultiAdminClient(nil, zap.NewNop())
-	m.clusterKeyFn = func(cl metav1.ObjectMetaAccessor, url string) string {
+	m.clusterKeyFn = func(cl *myspec.M3DBCluster, url string) string {
 		return cl.GetObjectMeta().GetName()
 	}
-	m.clusterURLFn = func(metav1.ObjectMetaAccessor) string {
+	m.clusterURLFn = func(*myspec.M3DBCluster) string {
 		return url
 	}
 	m.adminClientFn = func(...m3admin.Option) m3admin.Client {
@@ -65,6 +65,12 @@ func TestClusterURL(t *testing.T) {
 	cluster.Namespace = "foo"
 	url := clusterURL(cluster)
 	assert.Equal(t, "http://m3coordinator-a.foo:7201", url)
+
+	cluster.Spec.ExternalCoordinator = &myspec.ExternalCoordinatorConfig{
+		ServiceEndpoint: "my-custom-coordinator.other-namespace:1234",
+	}
+	url = clusterURL(cluster)
+	assert.Equal(t, "http://my-custom-coordinator.other-namespace:1234", url)
 }
 
 func TestClusterURLProxy(t *testing.T) {


### PR DESCRIPTION
We allow changing the selector that the coordinator service uses,
enabling users to control their M3DB clusters with coordinators that
live outside the cluster. This improves the ability to use
out-of-cluster coordinators, but has the limitation that the coordinator
must be in the same namespace as the cluster.

This PR extends external coordinator support to allow configuring a
static endpoint. This allows the user to manage the cluster with a
coordinator in a different namespace, i.e.
`global-coordinator.$OTHER_NS:7201`.