### PR TITLE
Add configurable port to health client

### DIFF
--- a/pkg/m3admin/health/client.go
+++ b/pkg/m3admin/health/client.go
@@ -25,19 +25,19 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/m3db/m3db-operator/pkg/k8sops/m3db"
 	"github.com/m3db/m3db-operator/pkg/m3admin"
 )
 
 const (
 	bootstrappedPath = "/bootstrapped"
 	m3dbServiceName  = "m3dbnode-m3-cluster-short"
-	defaultPort = 9002
 )
 
 type healthClient struct {
 	client m3admin.Client
 	url    string
-	port int
+	port   int
 }
 
 // Option provides an interface that can be used for setter options with the
@@ -73,7 +73,7 @@ func WithClient(cl m3admin.Client) Option {
 	})
 }
 
-// WithPort overrides the default port 9002. This does nothing if WithURL is used.
+// WithPort overrides the default port (m3db.PortM3DBHTTPNode). This does nothing if WithURL is used.
 func WithPort(port int) Option {
 	return optionFn(func(h *healthClient) error {
 		h.port = port
@@ -97,7 +97,7 @@ func NewClient(opts ...Option) (Client, error) {
 func (h *healthClient) Bootstrapped(namespace string, podName string) (bool, error) {
 	port := h.port
 	if port == 0 {
-		port = defaultPort
+		port = m3db.PortM3DBHTTPNode
 	}
 	url := h.url
 	if url == "" {

--- a/pkg/m3admin/health/client.go
+++ b/pkg/m3admin/health/client.go
@@ -84,10 +84,10 @@ func NewClient(opts ...Option) (Client, error) {
 	return hc, nil
 }
 
-func (h *healthClient) Bootstrapped(namespace string, podName string) (bool, error) {
+func (h *healthClient) Bootstrapped(namespace string, podName string, port int) (bool, error) {
 	url := h.url
 	if url == "" {
-		url = getPodURL(namespace, podName)
+		url = getPodURL(namespace, podName, port)
 	}
 
 	_, err := h.client.DoHTTPRequest(http.MethodGet, url+bootstrappedPath, nil)
@@ -98,6 +98,6 @@ func (h *healthClient) Bootstrapped(namespace string, podName string) (bool, err
 	return true, nil
 }
 
-func getPodURL(namespace string, podName string) string {
-	return fmt.Sprintf("http://%s.%s.%s", podName, m3dbServiceName, namespace)
+func getPodURL(namespace string, podName string, port int) string {
+	return fmt.Sprintf("http://%s.%s.%s:%d", podName, m3dbServiceName, namespace, port)
 }

--- a/pkg/m3admin/health/client_test.go
+++ b/pkg/m3admin/health/client_test.go
@@ -45,7 +45,7 @@ func TestBootstrapped(t *testing.T) {
 	defer s.Close()
 	client := newHealthClientWithURL(t, newM3adminClient(s.Client()), s.URL)
 
-	bootstrapped, err := client.Bootstrapped("foo", "bar", 0)
+	bootstrapped, err := client.Bootstrapped("foo", "bar")
 
 	require.NoError(t, err)
 	require.True(t, bootstrapped)
@@ -62,7 +62,28 @@ func TestBootstrapped_ValidateURL(t *testing.T) {
 
 	client := newHealthClient(t, adminClient)
 
-	bootstrapped, err := client.Bootstrapped("foo", "bar", 9002)
+	bootstrapped, err := client.Bootstrapped("foo", "bar")
+
+	require.NoError(t, err)
+	require.True(t, bootstrapped)
+}
+
+func TestBootstrapped_WithPort(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	adminClient := m3admin.NewMockClient(ctrl)
+	adminClient.EXPECT().DoHTTPRequest("GET", "http://bar.m3dbnode-m3-cluster-short.foo:8088/bootstrapped",
+		nil).
+		Return(&http.Response{}, nil)
+
+	client, err := NewClient(
+		WithClient(adminClient),
+		WithPort(8088),
+	)
+	require.NoError(t, err)
+
+	bootstrapped, err := client.Bootstrapped("foo", "bar")
 
 	require.NoError(t, err)
 	require.True(t, bootstrapped)
@@ -80,7 +101,7 @@ func TestBootstrapped_NotReady(t *testing.T) {
 	defer s.Close()
 	client := newHealthClientWithURL(t, newM3adminClient(s.Client()), s.URL)
 
-	bootstrapped, err := client.Bootstrapped("foo", "bar", 0)
+	bootstrapped, err := client.Bootstrapped("foo", "bar")
 
 	require.Error(t, err)
 	require.False(t, bootstrapped)

--- a/pkg/m3admin/health/client_test.go
+++ b/pkg/m3admin/health/client_test.go
@@ -45,7 +45,7 @@ func TestBootstrapped(t *testing.T) {
 	defer s.Close()
 	client := newHealthClientWithURL(t, newM3adminClient(s.Client()), s.URL)
 
-	bootstrapped, err := client.Bootstrapped("foo", "bar")
+	bootstrapped, err := client.Bootstrapped("foo", "bar", 0)
 
 	require.NoError(t, err)
 	require.True(t, bootstrapped)
@@ -56,12 +56,13 @@ func TestBootstrapped_ValidateURL(t *testing.T) {
 	defer ctrl.Finish()
 
 	adminClient := m3admin.NewMockClient(ctrl)
-	adminClient.EXPECT().DoHTTPRequest("GET", "http://bar.m3dbnode-m3-cluster-short.foo/bootstrapped", nil).
+	adminClient.EXPECT().DoHTTPRequest("GET", "http://bar.m3dbnode-m3-cluster-short.foo:9002/bootstrapped",
+		nil).
 		Return(&http.Response{}, nil)
 
 	client := newHealthClient(t, adminClient)
 
-	bootstrapped, err := client.Bootstrapped("foo", "bar")
+	bootstrapped, err := client.Bootstrapped("foo", "bar", 9002)
 
 	require.NoError(t, err)
 	require.True(t, bootstrapped)
@@ -79,7 +80,7 @@ func TestBootstrapped_NotReady(t *testing.T) {
 	defer s.Close()
 	client := newHealthClientWithURL(t, newM3adminClient(s.Client()), s.URL)
 
-	bootstrapped, err := client.Bootstrapped("foo", "bar")
+	bootstrapped, err := client.Bootstrapped("foo", "bar", 0)
 
 	require.Error(t, err)
 	require.False(t, bootstrapped)

--- a/pkg/m3admin/health/types.go
+++ b/pkg/m3admin/health/types.go
@@ -24,5 +24,5 @@ package health
 type Client interface {
 	// Bootstrapped returns true or false depending on the/ bootstrapped state
 	// of the provided dbnode.
-	Bootstrapped(namespace string, podName string) (bool, error)
+	Bootstrapped(namespace string, podName string, port int) (bool, error)
 }

--- a/pkg/m3admin/health/types.go
+++ b/pkg/m3admin/health/types.go
@@ -24,5 +24,5 @@ package health
 type Client interface {
 	// Bootstrapped returns true or false depending on the/ bootstrapped state
 	// of the provided dbnode.
-	Bootstrapped(namespace string, podName string, port int) (bool, error)
+	Bootstrapped(namespace string, podName string) (bool, error)
 }


### PR DESCRIPTION
We can't assume the server is listening on port 80

Thanks for contributing to the M3DB Operator! We'd love to accept your contribution, but we require that most issues
outside of trivial changes such as typo corrections have an issue associated with the pull request. So please [open an
issue](https://github.com/m3db/m3db-operator/issues/new) first!
