### PR TITLE
Add support for pod anti-affinity

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -98,6 +98,8 @@ IsolationGroup defines the name of zone as well attributes for the zone configur
 | ----- | ----------- | ------ | -------- |
 | name | Name is the value that will be used in StatefulSet labels, pod labels, and M3DB placement \"isolationGroup\" fields. | string | true |
 | nodeAffinityTerms | NodeAffinityTerms is an array of NodeAffinityTerm requirements, which are ANDed together to indicate what nodes an isolation group can be assigned to. | [][NodeAffinityTerm](#nodeaffinityterm) | false |
+| usePodAntiAffinity | UsePodAntiAffinity enables M3DB pod anti-affinity by using M3DB pod component labels to prevent multiple M3DB pods from being scheduled in the same failure domain, determined by podAffinityToplogyKey. | bool | false |
+| podAffinityToplogyKey | PodAffinityToplogyKey defines the node label used for pod anti-affinity. This parameter is required when usePodAntiAffinity is set to true. | string | false |
 | numInstances | NumInstances defines the number of instances. | int32 | true |
 | storageClassName | StorageClassName is the name of the StorageClass to use for this isolation group. This allows ensuring that PVs will be created in the same zone as the pinned statefulset on Kubernetes < 1.12 (when topology aware volume scheduling was introduced). Only has effect if the clusters `dataDirVolumeClaimTemplate` is non-nil. If set, the volume claim template will have its storageClassName field overridden per-isolationgroup. If unset the storageClassName of the volumeClaimTemplate will be used. | string | false |
 

--- a/pkg/apis/m3dboperator/v1alpha1/cluster.go
+++ b/pkg/apis/m3dboperator/v1alpha1/cluster.go
@@ -360,8 +360,8 @@ type IsolationGroup struct {
 	NodeAffinityTerms []NodeAffinityTerm `json:"nodeAffinityTerms,omitempty"`
 
 	// UsePodAntiAffinity enables M3DB pod anti-affinity by using M3DB pod
-	// component labels to prevent multiple M3DB pods from being scheduled on the
-	// same Kubernetes node.
+	// component labels to prevent multiple M3DB pods from being scheduled in the
+	// same failure domain, determined by podAffinityToplogyKey.
 	UsePodAntiAffinity bool `json:"usePodAntiAffinity,omitempty"`
 
 	// PodAffinityToplogyKey defines the node label used for pod anti-affinity.

--- a/pkg/apis/m3dboperator/v1alpha1/cluster.go
+++ b/pkg/apis/m3dboperator/v1alpha1/cluster.go
@@ -359,6 +359,15 @@ type IsolationGroup struct {
 	// to.
 	NodeAffinityTerms []NodeAffinityTerm `json:"nodeAffinityTerms,omitempty"`
 
+	// UsePodAntiAffinity enables M3DB pod anti-affinity by using M3DB pod
+	// component labels to prevent multiple M3DB pods from being scheduled on the
+	// same Kubernetes node.
+	UsePodAntiAffinity bool `json:"usePodAntiAffinity,omitempty"`
+
+	// PodAffinityToplogyKey defines the node label used for pod anti-affinity.
+	// This parameter is required when usePodAntiAffinity is set to true.
+	PodAffinityToplogyKey string `json:"podAffinityToplogyKey,omitempty"`
+
 	// NumInstances defines the number of instances.
 	NumInstances int32 `json:"numInstances"`
 

--- a/pkg/apis/m3dboperator/v1alpha1/openapi_generated.go
+++ b/pkg/apis/m3dboperator/v1alpha1/openapi_generated.go
@@ -686,6 +686,20 @@ func schema_pkg_apis_m3dboperator_v1alpha1_IsolationGroup(ref common.ReferenceCa
 							},
 						},
 					},
+					"usePodAntiAffinity": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UsePodAntiAffinity enables M3DB pod anti-affinity by using M3DB pod component labels to prevent multiple M3DB pods from being scheduled in the same failure domain, determined by podAffinityToplogyKey.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"podAffinityToplogyKey": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PodAffinityToplogyKey defines the node label used for pod anti-affinity. This parameter is required when usePodAntiAffinity is set to true.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"numInstances": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NumInstances defines the number of instances.",

--- a/pkg/k8sops/m3db/statefulset.go
+++ b/pkg/k8sops/m3db/statefulset.go
@@ -244,6 +244,7 @@ func GenerateStatefulSetPodAntiAffinity(isoGroup myspec.IsolationGroup) (*v1.Pod
 						},
 					},
 				},
+				TopologyKey: isoGroup.PodAffinityToplogyKey,
 			},
 		},
 	}, nil

--- a/pkg/k8sops/m3db/statefulset_test.go
+++ b/pkg/k8sops/m3db/statefulset_test.go
@@ -25,7 +25,10 @@ import (
 
 	myspec "github.com/m3db/m3db-operator/pkg/apis/m3dboperator/v1alpha1"
 
+	"github.com/m3db/m3db-operator/pkg/k8sops/labels"
+
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,7 +76,7 @@ func TestGenerateDownwardAPIVolumePath(t *testing.T) {
 	assert.Equal(t, exp, vm)
 }
 
-func TestGenerateStatefulSetAffinity(t *testing.T) {
+func TestGenerateStatefulSetNodeAffinity(t *testing.T) {
 	type expTerm struct {
 		key    string
 		values []string
@@ -155,18 +158,18 @@ func TestGenerateStatefulSetAffinity(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		affinity, err := GenerateStatefulSetAffinity(test.isoGroup)
+		nodeaffinity, err := GenerateStatefulSetNodeAffinity(test.isoGroup)
 		if test.expErr != nil {
 			assert.Equal(t, test.expErr, err)
 			continue
 		}
 
 		if len(test.expTerms) == 0 {
-			assert.Nil(t, affinity)
+			assert.Nil(t, nodeaffinity)
 			continue
 		}
 
-		terms := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+		terms := nodeaffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 		assert.Len(t, terms, 1)
 
 		expTerms := make([]corev1.NodeSelectorRequirement, len(test.expTerms))
@@ -179,5 +182,71 @@ func TestGenerateStatefulSetAffinity(t *testing.T) {
 		}
 
 		assert.Equal(t, expTerms, terms[0].MatchExpressions)
+	}
+}
+
+func TestGenerateStatefulSetPodAntiAffinity(t *testing.T) {
+	tests := []struct {
+		isoGroup myspec.IsolationGroup
+		expBool  bool
+		expErr   error
+	}{
+		{
+			isoGroup: myspec.IsolationGroup{
+				Name: "group1",
+			},
+			expBool: false,
+		},
+		{
+			isoGroup: myspec.IsolationGroup{
+				Name:               "group2",
+				UsePodAntiAffinity: false,
+			},
+			expBool: false,
+		},
+		{
+			isoGroup: myspec.IsolationGroup{
+				Name:                  "group3",
+				UsePodAntiAffinity:    true,
+				PodAffinityToplogyKey: "hostname",
+			},
+			expBool: true,
+		},
+		{
+			isoGroup: myspec.IsolationGroup{
+				Name:               "group4",
+				UsePodAntiAffinity: true,
+			},
+			expBool: true,
+			expErr:  errEmptyPodAffinityToplogyKey,
+		},
+	}
+
+	for _, test := range tests {
+		antiaffinity, err := GenerateStatefulSetPodAntiAffinity(test.isoGroup)
+
+		if !test.expBool {
+			assert.Nil(t, antiaffinity)
+			continue
+		}
+
+		if test.expErr != nil {
+			assert.Equal(t, test.expErr, err)
+			continue
+		}
+
+		terms := antiaffinity.RequiredDuringSchedulingIgnoredDuringExecution
+
+		expTerms := &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      labels.Component,
+					Operator: "In",
+					Values:   []string{labels.ComponentM3DBNode},
+				},
+			},
+		}
+
+		assert.Equal(t, expTerms, terms[0].LabelSelector)
 	}
 }


### PR DESCRIPTION
Adds functionality to enable pod anti-affinity by matching for the component label against the `componentM3DBNode` value.  This functionality is disabled by default to prevent resource strain on k8s clusters.  This change also splits up the functionality of the `GenerateStatefulSetAffinity` function into two sub-functions handling node affinity and pod anti-affinity.

Fixes #123