### PR TITLE
[controller] Maintain map of StatefulSet generations to avoid stale cache

### DIFF
--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -100,8 +100,9 @@ func (deps *testDeps) newController(t *testing.T) *M3DBController {
 			podWorkQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), podWorkQueueName),
 			podLister:    deps.podLister,
 
-			statefulSetLister: deps.statefulSetLister,
-			recorder:          eventer.NewNopPoster(),
+			statefulSetLister:      deps.statefulSetLister,
+			statefulSetCheckpoints: make(map[string]int64),
+			recorder:               eventer.NewNopPoster(),
 		},
 
 		k8sclient:     k8sopsClient,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -762,13 +762,18 @@ func (c *M3DBController) getChildStatefulSets(cluster *myspec.M3DBCluster) ([]*a
 	// Once we reach here we know that all StatefulSet's returned by the Lister are
 	// up-to-date. But we also need to check that the Lister isn't missing any entirely.
 	for want := range c.statefulSetCheckpoints {
+		var found bool
 		for _, sts := range childrenSets {
 			if sts.Name == want {
-				continue
+				found = true
+				break
 			}
 		}
-		c.logger.Warn("StatefulSetLister is missing a StatefulSet", zap.String("name", want))
-		return nil, errStaleCache
+
+		if !found {
+			c.logger.Warn("StatefulSetLister is missing a StatefulSet", zap.String("name", want))
+			return nil, errStaleCache
+		}
 	}
 
 	return childrenSets, nil


### PR DESCRIPTION
This commit updates the controller to maintain a map from the name of a `StatefulSet` to the most recent generation that the controller has seen. This map is updated after every `StatefulSet` operation and checked in `getChildStatefulSets` to make sure that the list of `StatefulSet`'s that is returned by the informer we have is not stale. This should fix #268.

I haven't written any tests yet but wanted to put up this PR to start a discussion of whether we want to use this approach. 