### PR TITLE
[controller] Run with 1 worker

### DIFF
--- a/cmd/m3db-operator/main.go
+++ b/cmd/m3db-operator/main.go
@@ -264,7 +264,7 @@ func main() {
 		os.Exit(1)
 	}()
 
-	if err := controller.Run(2, stopCh); err != nil {
+	if err := controller.Run(1, stopCh); err != nil {
 		logger.Fatal("error running controller", zap.Error(err))
 	}
 }


### PR DESCRIPTION
In all of our test cases of parallel updates, we noticed 2 sets get updated
at once. It turns out 2 is also the number of parallel workers we run.

Running more than 1 worker means an M3DB cluster may have two
statefulsets updated at once. This setting reflects what
controller-runtime does:
https://github.com/kubernetes-sigs/controller-runtime/blob/0fcf28efebc9a977c954f00d40af966d6a4aeae3/pkg/controller/controller.go#L32

Fixes #268 