### PR TITLE
[controller] Ensure k8s statefulset statuses are fresh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,13 @@ RUN apk add --update ca-certificates openssl && \
 # Install Build Binaries
 RUN apk add --update curl git make bash
 
-# Add source code
 RUN mkdir -p /go/src/github.com/m3db/m3db-operator
+
+ADD go.mod go.sum /go/src/github.com/m3db/m3db-operator/
+RUN cd /go/src/github.com/m3db/m3db-operator/ && \
+  go mod download
+
+# Add source code
 ADD . /go/src/github.com/m3db/m3db-operator
 
 # Build m3dbnode binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,8 @@ RUN apk add --update ca-certificates openssl && \
 # Install Build Binaries
 RUN apk add --update curl git make bash
 
-RUN mkdir -p /go/src/github.com/m3db/m3db-operator
-
-ADD go.mod go.sum /go/src/github.com/m3db/m3db-operator/
-RUN cd /go/src/github.com/m3db/m3db-operator/ && \
-  go mod download
-
 # Add source code
+RUN mkdir -p /go/src/github.com/m3db/m3db-operator
 ADD . /go/src/github.com/m3db/m3db-operator
 
 # Build m3dbnode binary

--- a/cmd/m3db-operator/main.go
+++ b/cmd/m3db-operator/main.go
@@ -264,7 +264,7 @@ func main() {
 		os.Exit(1)
 	}()
 
-	if err := controller.Run(2, stopCh); err != nil {
+	if err := controller.Run(1, stopCh); err != nil {
 		logger.Fatal("error running controller", zap.Error(err))
 	}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -498,7 +498,7 @@ func (c *M3DBController) handleClusterUpdate(cluster *myspec.M3DBCluster) error 
 	// If any of the statefulsets aren't ready, wait until they are as we'll get
 	// another event (ready == bootstrapped)
 	for _, sts := range childrenSets {
-		c.logger.Info("processing set",
+		c.logger.Debug("processing set",
 			zap.String("namespace", sts.Namespace),
 			zap.String("name", sts.Name),
 			zap.Int32("readyReplicas", sts.Status.ReadyReplicas),
@@ -579,7 +579,10 @@ func (c *M3DBController) handleClusterUpdate(cluster *myspec.M3DBCluster) error 
 			zap.Int32("expected_readyReplicas", expected.Status.ReadyReplicas),
 			zap.Int32("expected_updatedReplicas", expected.Status.UpdatedReplicas),
 			zap.String("expected_currentRevision", expected.Status.CurrentRevision),
-			zap.String("expected_updateRevision", expected.Status.UpdateRevision))
+			zap.String("expected_updateRevision", expected.Status.UpdateRevision),
+			zap.Int64("generation", expected.Generation),
+			zap.Int64("observed", expected.Status.ObservedGeneration),
+		)
 
 		return nil
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -73,6 +73,7 @@ const (
 
 var (
 	errOrphanedPod         = errors.New("pod does not belong to an m3db cluster")
+	errNoSetLabel          = errors.New("pod does not have a parent statefulset error")
 	errInvalidNumIsoGroups = errors.New("number of isolationgroups not equal to replication factor")
 	errNonUniqueIsoGroups  = errors.New("isolation group names are not unique")
 )
@@ -475,9 +476,49 @@ func (c *M3DBController) handleClusterUpdate(cluster *myspec.M3DBCluster) error 
 		}
 	}
 
+	// At this point we have the desired number of statefulsets, and every pod
+	// across those sets is bootstrapped. However some may be bootstrapped because
+	// they own no shards. Check to see that all pods are in the placement.
+	clusterPodsSelector := klabels.SelectorFromSet(labels.BaseLabels(cluster))
+	pods, err := c.podLister.Pods(cluster.Namespace).List(clusterPodsSelector)
+	if err != nil {
+		return fmt.Errorf("could not list pods to check update revision: %v", err)
+	}
+
+	// For all statefulsets, ensure their observered generation is up to date.
+	// This means that the k8s statefulset controller has updated Status (and
+	// therefore ready replicas + updated replicas). If observed generation !=
+	// generation, it means Status will contain stale info.
+	for _, sts := range childrenSets {
+		if sts.Generation != sts.Status.ObservedGeneration {
+			c.logger.Warn("stateful set not up to date",
+				zap.String("namespace", sts.Namespace),
+				zap.String("name", sts.Name),
+				zap.Int32("readyReplicas", sts.Status.ReadyReplicas),
+				zap.Int32("updatedReplicas", sts.Status.UpdatedReplicas),
+				zap.String("currentRevision", sts.Status.CurrentRevision),
+				zap.String("updateRevision", sts.Status.UpdateRevision),
+				zap.Int64("generation", sts.Generation),
+				zap.Int64("observed", sts.Status.ObservedGeneration),
+			)
+			return fmt.Errorf("set %s generation is not up to date (current: %d, observed: %d)", sts.Name, sts.Generation, sts.Status.ObservedGeneration)
+		}
+	}
+
 	// If any of the statefulsets aren't ready, wait until they are as we'll get
 	// another event (ready == bootstrapped)
 	for _, sts := range childrenSets {
+		c.logger.Info("processing set",
+			zap.String("namespace", sts.Namespace),
+			zap.String("name", sts.Name),
+			zap.Int32("readyReplicas", sts.Status.ReadyReplicas),
+			zap.Int32("updatedReplicas", sts.Status.UpdatedReplicas),
+			zap.String("currentRevision", sts.Status.CurrentRevision),
+			zap.String("updateRevision", sts.Status.UpdateRevision),
+			zap.Int64("generation", sts.Generation),
+			zap.Int64("observed", sts.Status.ObservedGeneration),
+		)
+
 		if sts.Spec.Replicas == nil {
 			c.logger.Warn("skip check for statefulset, replicas is nil",
 				zap.String("name", sts.Name),
@@ -539,7 +580,17 @@ func (c *M3DBController) handleClusterUpdate(cluster *myspec.M3DBCluster) error 
 			return err
 		}
 
-		c.logger.Info("updated statefulset", zap.String("name", name))
+		c.logger.Info("updated statefulset",
+			zap.String("name", expected.Name),
+			zap.Int32("actual_readyReplicas", actual.Status.ReadyReplicas),
+			zap.Int32("actual_updatedReplicas", actual.Status.UpdatedReplicas),
+			zap.String("actual_currentRevision", actual.Status.CurrentRevision),
+			zap.String("actual_updateRevision", actual.Status.UpdateRevision),
+			zap.Int32("expected_readyReplicas", expected.Status.ReadyReplicas),
+			zap.Int32("expected_updatedReplicas", expected.Status.UpdatedReplicas),
+			zap.String("expected_currentRevision", expected.Status.CurrentRevision),
+			zap.String("expected_updateRevision", expected.Status.UpdateRevision))
+
 		return nil
 	}
 
@@ -564,10 +615,11 @@ func (c *M3DBController) handleClusterUpdate(cluster *myspec.M3DBCluster) error 
 	// At this point we have the desired number of statefulsets, and every pod
 	// across those sets is bootstrapped. However some may be bootstrapped because
 	// they own no shards. Check to see that all pods are in the placement.
-	selector := klabels.SelectorFromSet(labels.BaseLabels(cluster))
-	pods, err := c.podLister.Pods(cluster.Namespace).List(selector)
+	// NB(schallert): we also fetch pods above, but out of paranoia re-fetch to
+	// match old behavior.
+	pods, err = c.podLister.Pods(cluster.Namespace).List(clusterPodsSelector)
 	if err != nil {
-		return fmt.Errorf("error listing pods: %v", err)
+		return fmt.Errorf("error listing pods to construct placement: %v", err)
 	}
 
 	placement, err := c.adminClient.placementClientForCluster(cluster).Get()
@@ -867,7 +919,7 @@ func (c *M3DBController) handlePodEvent(key string) error {
 
 func (c *M3DBController) handlePodUpdate(pod *corev1.Pod) error {
 	// We only process pods that are members of m3db clusters.
-	if _, found := getClusterValue(pod); !found {
+	if _, err := getClusterValue(pod); err != nil {
 		return nil
 	}
 
@@ -945,19 +997,19 @@ func (c *M3DBController) handlePodUpdate(pod *corev1.Pod) error {
 	return nil
 }
 
-func getClusterValue(pod *corev1.Pod) (string, bool) {
+func getClusterValue(pod *corev1.Pod) (string, error) {
 	cluster, ok := pod.Labels[labels.Cluster]
 	if !ok {
-		return "", false
+		return "", errOrphanedPod
 	}
 
-	return cluster, true
+	return cluster, nil
 }
 
 func (c *M3DBController) getParentCluster(pod *corev1.Pod) (*myspec.M3DBCluster, error) {
-	clusterName, found := getClusterValue(pod)
-	if !found {
-		return nil, errOrphanedPod
+	clusterName, err := getClusterValue(pod)
+	if err != nil {
+		return nil, err
 	}
 
 	cluster, err := c.clusterLister.M3DBClusters(pod.Namespace).Get(clusterName)
@@ -1030,6 +1082,13 @@ func updatedStatefulSet(
 		delete(actual.Annotations, annotations.Update)
 		return actual, true, nil
 	}
+
+	// Ensure we keep old object meta so that resource version info can be used by
+	// K8s API for conflict resolution.
+	expected.ObjectMeta = *actual.ObjectMeta.DeepCopy()
+	// Reset expected annotations since we ensure their final state below.
+	expected.ObjectMeta.Annotations = map[string]string{}
+	expected.Status = actual.DeepCopy().Status
 
 	copyAnnotations(expected, actual)
 	return expected, true, nil

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -421,16 +421,16 @@ func TestInstancesInIsoGroup(t *testing.T) {
 
 func TestGetClusterValue(t *testing.T) {
 	pod := &corev1.Pod{}
-	cluster, ok := getClusterValue(pod)
-	assert.False(t, ok)
+	cluster, err := getClusterValue(pod)
+	assert.Error(t, err)
 	assert.Equal(t, "", cluster)
 
 	pod.Labels = map[string]string{
 		"operator.m3db.io/cluster": "foo",
 	}
 
-	cluster, ok = getClusterValue(pod)
-	assert.True(t, ok)
+	cluster, err = getClusterValue(pod)
+	assert.NoError(t, err)
 	assert.Equal(t, "foo", cluster)
 }
 


### PR DESCRIPTION
In debugging #268, I discovered that in all cases where we updated more
than 1 statefulset, it was because the observed generation on the set
was 1 less than the set's actual generation. This means that the
Kubernetes statefulset controller had not yet processed the update, and
that the information on `Status` that we check (ready replicas, current
replicas, etc.) was not up-to-date.

Also out of paranoia, I changed the update behavior to ensure that we
keep the old object meta fields around when we send the `Update` to
Kubernetes. I think if this isn't the case, we potentially overwrite a
set even if it had changed since we last process it.

This PR ensures that we stop processing the cluster if any of the set
statuses are not fresh, and that we use familiar conflict methods on set
updated.

Closes #268.