### PR TITLE
Add support for parallel node updates within a statefulset

### DIFF
--- a/pkg/apis/m3dboperator/v1alpha1/cluster.go
+++ b/pkg/apis/m3dboperator/v1alpha1/cluster.go
@@ -319,6 +319,10 @@ type ClusterSpec struct {
 	// SidecarVolumes is used to add any volumes that are required by sidecar
 	// containers.
 	SidecarVolumes []corev1.Volume `json:"sidecarVolumes,omitempty"`
+
+	// OnDeleteUpdateStrategy sets StatefulSets created by the operator to
+	// have OnDelete as the update strategy instead of RollingUpdate.
+	OnDeleteUpdateStrategy bool `json:"onDeleteUpdateStrategy,omitempty"`
 }
 
 // ExternalCoordinatorConfig defines parameters for using an external

--- a/pkg/apis/m3dboperator/v1alpha1/openapi_generated.go
+++ b/pkg/apis/m3dboperator/v1alpha1/openapi_generated.go
@@ -650,6 +650,13 @@ func schema_pkg_apis_m3dboperator_v1alpha1_ClusterSpec(ref common.ReferenceCallb
 							},
 						},
 					},
+					"onDeleteUpdateStrategy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "OnDeleteUpdateStrategy sets StatefulSets created by the operator to have OnDelete as the update strategy instead of RollingUpdate.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"parallelPodManagement"},
 			},

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -133,6 +133,7 @@ func setupTestCluster(
 	}
 
 	for _, pod := range pods {
+		// nolint:makezero
 		objects = append(objects, runtime.Object(pod))
 	}
 
@@ -217,14 +218,15 @@ func waitForStatefulSets(
 		return false, nil, nil
 	})
 
-	controller.kubeClient.(*kubefake.Clientset).PrependReactor("delete", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
-		podName := action.(kubetesting.DeleteActionImpl).GetName()
-		mu.Lock()
-		updatedPods = append(updatedPods, podName)
-		mu.Unlock()
+	controller.kubeClient.(*kubefake.Clientset).PrependReactor(
+		"delete", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+			podName := action.(kubetesting.DeleteActionImpl).GetName()
+			mu.Lock()
+			updatedPods = append(updatedPods, podName)
+			mu.Unlock()
 
-		return false, nil, nil
-	})
+			return false, nil, nil
+		})
 
 	// Iterate through the expected stateful sets twice (or at least 5 times) to make sure
 	// we see all stateful sets that we expect and also be able to catch any extra stateful
@@ -713,7 +715,9 @@ func TestHandleUpdateClusterCreatesStatefulSets(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cluster, deps := setupTestCluster(t, *test.cluster, test.sets, nil, test.replicationFactor, 1, false)
+			cluster, deps := setupTestCluster(
+				t, *test.cluster, test.sets, nil, test.replicationFactor, 1, false,
+			)
 			defer deps.cleanup()
 			c := deps.newController(t)
 
@@ -1071,7 +1075,13 @@ func TestHandleUpdateClusterFrozen(t *testing.T) {
 	assert.Equal(t, int64(0), count.Load())
 }
 
-func generateSets(clusterName string, rf int32, updateVal string, withAnnotation bool) []*metav1.ObjectMeta {
+func generateSets(
+	// nolint:unparam
+	clusterName string,
+	rf int32,
+	updateVal string,
+	withAnnotation bool,
+) []*metav1.ObjectMeta {
 	var sets []*metav1.ObjectMeta
 	for i := 0; i < int(rf); i++ {
 		var ann map[string]string
@@ -1087,6 +1097,7 @@ func generateSets(clusterName string, rf int32, updateVal string, withAnnotation
 	return sets
 }
 
+// nolint:unparam
 func generatePods(clusterName string, rf int32, nodes int32, revision string) []*corev1.Pod {
 	var pods []*corev1.Pod
 	for i := 0; i < int(rf); i++ {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1021,7 +1021,7 @@ func TestHandleUpdateClusterOnDeleteStrategy(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			nodes := int32(len(test.pods))
+			nodes := int32(len(test.pods) / len(test.sets))
 			cluster, deps := setupTestCluster(
 				t, *rawCluster, test.sets, test.pods, int(replicas), nodes, true,
 			)
@@ -1104,7 +1104,8 @@ func generatePods(clusterName string, rf int32, nodes int32, revision string) []
 		for j := 0; j < int(nodes); j++ {
 			pods = append(pods, &corev1.Pod{
 				ObjectMeta: *newMeta(fmt.Sprintf("%s-rep%d-%d", clusterName, i, j), map[string]string{
-					"controller-revision-hash": fmt.Sprintf("%s-rep%d-%s", clusterName, i, revision),
+					"controller-revision-hash":      fmt.Sprintf("%s-rep%d-%s", clusterName, i, revision),
+					"operator.m3db.io/stateful-set": fmt.Sprintf("%s-rep%d", clusterName, i),
 				}, nil),
 			})
 		}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -232,7 +232,7 @@ func waitForStatefulSets(
 	// we see all stateful sets that we expect and also be able to catch any extra stateful
 	// sets that we don't.
 	var (
-		iters           = math.Max(float64(2*len(opts.expectedStatefulSets)), 5)
+		iters           = math.Max(float64(2*len(opts.expectedStatefulSets)), 10)
 		finalErr        error
 		podUpdateGroups [][]string
 	)

--- a/pkg/k8sops/annotations/annotations.go
+++ b/pkg/k8sops/annotations/annotations.go
@@ -37,7 +37,12 @@ const (
 	// Update is the annotation used by the operator to determine if a StatefulSet is
 	// allowed to be updated.
 	Update = "operator.m3db.io/update"
-
+	// ParallelUpdate is the annotation used by the operator to determine if a StatefulSet
+	// is allowed to be updated in parallel.
+	ParallelUpdate = "operator.m3db.io/parallel-update"
+	// ParallelUpdateInProgress is the annotation used by the operator indicate a parallel update
+	// is underway. This annotation should only be used by the operator.
+	ParallelUpdateInProgress = "operator.m3db.io/parallel-update-in-progress"
 	// EnabledVal is the value that indicates an annotation is enabled.
 	EnabledVal = "enabled"
 )

--- a/pkg/k8sops/m3db/generators_test.go
+++ b/pkg/k8sops/m3db/generators_test.go
@@ -274,6 +274,9 @@ func TestGenerateStatefulSet(t *testing.T) {
 					ServiceAccountName: "m3db-account1",
 				},
 			},
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+			},
 			VolumeClaimTemplates: []v1.PersistentVolumeClaim{
 				{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/k8sops/m3db/statefulset.go
+++ b/pkg/k8sops/m3db/statefulset.go
@@ -184,6 +184,10 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 		stsSpec.PodManagementPolicy = appsv1.ParallelPodManagement
 	}
 
+	if cluster.Spec.OnDeleteUpdateStrategy {
+		stsSpec.UpdateStrategy.Type = appsv1.OnDeleteStatefulSetStrategyType
+	}
+
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        ssName,

--- a/pkg/k8sops/m3db/statefulset.go
+++ b/pkg/k8sops/m3db/statefulset.go
@@ -186,6 +186,9 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 
 	if cluster.Spec.OnDeleteUpdateStrategy {
 		stsSpec.UpdateStrategy.Type = appsv1.OnDeleteStatefulSetStrategyType
+	} else {
+		// NB(nate); This is the default, but set anyway out of a healthy paranoia.
+		stsSpec.UpdateStrategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
 	}
 
 	return &appsv1.StatefulSet{


### PR DESCRIPTION
This commits allows multiple nodes to be updated and deployed
at the same time within a statefulset. Opting into this behavior
requires the user to update the ClusterSpec to set OnDeleteUpdateStrategy
to true. When this is set, the operator will watch for the
operator.m3db.io/parallel-update annotation on statefulsets. When found,
the operator will attempt to update each statefulset, rolling N many
pods at a time where N is the value of the parallel-update annotation.

Thanks for contributing to the M3DB Operator! We'd love to accept your contribution, but we require that most issues
outside of trivial changes such as typo corrections have an issue associated with the pull request. So please [open an
issue](https://github.com/m3db/m3db-operator/issues/new) first!
