### PR TITLE
[k8sops] Remove liveness probes from DB

### DIFF
--- a/pkg/k8sops/m3db/generators.go
+++ b/pkg/k8sops/m3db/generators.go
@@ -44,8 +44,7 @@ const (
 	_probeInitialDelaySeconds = 10
 	_probeFailureThreshold    = 15
 
-	_probePathHealth = "/health"
-	_probePathReady  = "/bootstrappedinplacementornoplacement"
+	_probePathReady = "/bootstrappedinplacementornoplacement"
 
 	_dataDirectory             = "/var/lib/m3db/"
 	_dataVolumeName            = "m3db-data"

--- a/pkg/k8sops/m3db/generators_test.go
+++ b/pkg/k8sops/m3db/generators_test.go
@@ -85,19 +85,6 @@ func TestGenerateStatefulSet(t *testing.T) {
 
 	ssName := StatefulSetName(clusterName, 0)
 
-	health := &v1.Probe{
-		TimeoutSeconds:      _probeTimeoutSeconds,
-		InitialDelaySeconds: _probeInitialDelaySeconds,
-		FailureThreshold:    _probeFailureThreshold,
-		Handler: v1.Handler{
-			HTTPGet: &v1.HTTPGetAction{
-				Port:   intstr.FromInt(PortM3DBHTTPNode),
-				Path:   _probePathHealth,
-				Scheme: v1.URISchemeHTTP,
-			},
-		},
-	}
-
 	readiness := &v1.Probe{
 		TimeoutSeconds:      _probeTimeoutSeconds,
 		InitialDelaySeconds: _probeInitialDelaySeconds,
@@ -172,7 +159,6 @@ func TestGenerateStatefulSet(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Name:           ssName,
-							LivenessProbe:  health,
 							ReadinessProbe: readiness,
 							SecurityContext: &v1.SecurityContext{
 								RunAsUser: pointer.Int64Ptr(20),

--- a/pkg/k8sops/m3db/statefulset.go
+++ b/pkg/k8sops/m3db/statefulset.go
@@ -66,22 +66,6 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 
 	objAnnotations := annotations.PodAnnotations(cluster)
 
-	// TODO(schallert): we're currently using the health of the coordinator for
-	// liveness probes until https://github.com/m3db/m3/issues/996 is fixed. Move
-	// to the dbnode's health endpoint once fixed.
-	probeHealth := &v1.Probe{
-		TimeoutSeconds:      _probeTimeoutSeconds,
-		InitialDelaySeconds: _probeInitialDelaySeconds,
-		FailureThreshold:    _probeFailureThreshold,
-		Handler: v1.Handler{
-			HTTPGet: &v1.HTTPGetAction{
-				Port:   intstr.FromInt(PortM3DBHTTPNode),
-				Path:   _probePathHealth,
-				Scheme: v1.URISchemeHTTP,
-			},
-		},
-	}
-
 	probeReady := &v1.Probe{
 		TimeoutSeconds:      _probeTimeoutSeconds,
 		InitialDelaySeconds: _probeInitialDelaySeconds,
@@ -110,7 +94,6 @@ func NewBaseStatefulSet(ssName, isolationGroup string, cluster *myspec.M3DBClust
 		Name:            ssName,
 		SecurityContext: specSecurityCtx,
 		ReadinessProbe:  probeReady,
-		LivenessProbe:   probeHealth,
 		Command: []string{
 			"m3dbnode",
 		},


### PR DESCRIPTION
We already use readiness probes to make sure dbnodes are bootstrapped
before taking various actions. Liveness probes are usually a good idea,
but in the case of the DB we'd rather a deadlocked node remain up so we
can debug vs. automatically killing it.