### PR TITLE
[placement] Allow zone to be overridden

### DIFF
--- a/pkg/apis/m3dboperator/v1alpha1/cluster.go
+++ b/pkg/apis/m3dboperator/v1alpha1/cluster.go
@@ -323,6 +323,11 @@ type ClusterSpec struct {
 	// OnDeleteUpdateStrategy sets StatefulSets created by the operator to
 	// have OnDelete as the update strategy instead of RollingUpdate.
 	OnDeleteUpdateStrategy bool `json:"onDeleteUpdateStrategy,omitempty"`
+
+	// Zone defines the zone that placement instances will be written to if set.
+	// If not set, the default zone of "embedded" will be used.
+	// +optional
+	Zone string `json:"zone,omitempty"`
 }
 
 // ExternalCoordinatorConfig defines parameters for using an external

--- a/pkg/apis/m3dboperator/v1alpha1/openapi_generated.go
+++ b/pkg/apis/m3dboperator/v1alpha1/openapi_generated.go
@@ -657,6 +657,13 @@ func schema_pkg_apis_m3dboperator_v1alpha1_ClusterSpec(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"zone": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Zone defines the zone that placement instances will be written to if set. If not set, the default zone of \"embedded\" will be used.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"parallelPodManagement"},
 			},

--- a/pkg/k8sops/m3db/placement.go
+++ b/pkg/k8sops/m3db/placement.go
@@ -88,10 +88,15 @@ func PlacementInstanceFromPod(cluster *myspec.M3DBCluster, pod *corev1.Pod, idPr
 		return nil, pkgerrors.WithMessage(err, "cannot execute node endpoint template")
 	}
 
+	zone := cluster.Spec.Zone
+	if zone == "" {
+		zone = _zoneEmbedded
+	}
+
 	instance := &placementpb.Instance{
 		Id:             idStr,
 		IsolationGroup: isoGroup,
-		Zone:           _zoneEmbedded,
+		Zone:           zone,
 		Weight:         100,
 		Hostname:       pod.Name + "." + epCtx.M3DBService,
 		Endpoint:       str.String(),

--- a/pkg/k8sops/m3db/placement_test.go
+++ b/pkg/k8sops/m3db/placement_test.go
@@ -90,4 +90,20 @@ func TestPlacementInstanceFromPod(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expInst, inst)
 	})
+	t.Run("zone override", func(t *testing.T) {
+		cluster.Spec.Zone = "embedded-override"
+		expInst := &placementpb.Instance{
+			Id:             `{"name":"pod-a"}`,
+			IsolationGroup: "zone-a",
+			Zone:           "embedded-override",
+			Weight:         100,
+			Hostname:       "pod-a.m3dbnode-cluster-a",
+			Endpoint:       "pod-a.m3dbnode-cluster-a.my_ns:9000",
+			Port:           9000,
+		}
+
+		inst, err := PlacementInstanceFromPod(cluster, pod, idProvider)
+		assert.NoError(t, err)
+		assert.Equal(t, expInst, inst)
+	})
 }


### PR DESCRIPTION
This allows us to direct placement writes
to an etcd cluster other than the hardcoded "embedded"
zone.