### PR TITLE
[build] Use --short in GITSHA calculation

### DIFF
--- a/build/build-docker.sh
+++ b/build/build-docker.sh
@@ -11,7 +11,7 @@ fi
 
 : ${IMAGE:?"Need to set IMAGE, e.g. gcr.io/<repo>/<your>-operator"}
 
-GITSHA="$(git rev-parse HEAD)"
+GITSHA="$(git rev-parse --short HEAD)"
 
 echo "building container ${IMAGE}:${GITSHA}..."
 docker build -t "${IMAGE}:${GITSHA}" -f Dockerfile .


### PR DESCRIPTION
`git rev-parse HEAD` won't return an 8 character SHA by default, which we want for our docker tags

Thanks for contributing to the M3DB Operator! We'd love to accept your contribution, but we require that most issues
outside of trivial changes such as typo corrections have an issue associated with the pull request. So please [open an
issue](https://github.com/m3db/m3db-operator/issues/new) first!
