### PR TITLE
[m3admin-client] Incorporate zone into client cache

### DIFF
--- a/pkg/controller/m3admin_client.go
+++ b/pkg/controller/m3admin_client.go
@@ -63,7 +63,8 @@ type multiAdminClient struct {
 
 // clusterKey returns a map key for a given cluster.
 func clusterKey(cluster *myspec.M3DBCluster, url string) string {
-	return cluster.Namespace + "/" + cluster.Name + "/" + url
+	// nb: zone can be empty, but we still want to include it in the cache key in case it is set.
+	return cluster.Namespace + "/" + cluster.Name + "/" + cluster.Spec.Zone + "/" + url
 }
 
 // clusterURL returns the URL to hit

--- a/pkg/controller/m3admin_client_test.go
+++ b/pkg/controller/m3admin_client_test.go
@@ -55,7 +55,11 @@ func newTestAdminClient(cl m3admin.Client, url string) *multiAdminClient {
 func TestClusterKey(t *testing.T) {
 	cluster := newM3DBCluster("ns", "a")
 	key := clusterKey(cluster, "clustera.local")
-	assert.Equal(t, "ns/a/clustera.local", key)
+	assert.Equal(t, "ns/a//clustera.local", key)
+
+	cluster.Spec.Zone = "m3db"
+	keyWithZone := clusterKey(cluster, "clustera.local")
+	assert.Equal(t, "ns/a/m3db/clustera.local", keyWithZone)
 }
 
 func TestClusterURL(t *testing.T) {


### PR DESCRIPTION
Without this change, we could reuse clients without the proper zone header set, meaning etcd writes could be misdirected when cluster specs change during the duration of the operator's lifetime.