### PR TITLE
[api] Allow blocking cluster scale down

### DIFF
--- a/pkg/apis/m3dboperator/v1alpha1/cluster.go
+++ b/pkg/apis/m3dboperator/v1alpha1/cluster.go
@@ -328,6 +328,11 @@ type ClusterSpec struct {
 	// If not set, the default zone of "embedded" will be used.
 	// +optional
 	Zone string `json:"zone,omitempty"`
+
+	// PreventScaleDown will prevent the operator from removing any nodes from a
+	// cluster if set to true.
+	// +optional
+	PreventScaleDown bool `json:"preventScaleDown,omitempty"`
 }
 
 // ExternalCoordinatorConfig defines parameters for using an external

--- a/pkg/apis/m3dboperator/v1alpha1/openapi_generated.go
+++ b/pkg/apis/m3dboperator/v1alpha1/openapi_generated.go
@@ -664,6 +664,13 @@ func schema_pkg_apis_m3dboperator_v1alpha1_ClusterSpec(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"preventScaleDown": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PreventScaleDown will prevent the operator from removing any nodes from a cluster if set to true.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"parallelPodManagement"},
 			},

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -735,7 +735,8 @@ func (c *M3DBController) handleClusterUpdate(cluster *myspec.M3DBCluster) error 
 			newCount = current + 1
 		} else {
 			if cluster.Spec.PreventScaleDown {
-				return pkgerrors.Errorf("cannot shrink statefulset %s/%s, preventScaleDown is true", set.Namespace, set.Name)
+				return pkgerrors.Errorf("cannot shrink statefulset %s/%s, preventScaleDown is true",
+					set.Namespace, set.Name)
 			}
 			newCount = current - 1
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -734,6 +734,9 @@ func (c *M3DBController) handleClusterUpdate(cluster *myspec.M3DBCluster) error 
 		if current < desired {
 			newCount = current + 1
 		} else {
+			if cluster.Spec.PreventScaleDown {
+				return pkgerrors.Errorf("cannot shrink statefulset %s/%s, preventScaleDown is true", set.Namespace, set.Name)
+			}
 			newCount = current - 1
 		}
 		setLogger.Info("resizing set, desired != current", zap.Int32("newSize", newCount))

--- a/pkg/controller/update_cluster.go
+++ b/pkg/controller/update_cluster.go
@@ -515,6 +515,10 @@ func (c *M3DBController) expandPlacementForSet(cluster *myspec.M3DBCluster, set 
 // removes the last pod in the StatefulSet from the active placement, enabling
 // the StatefulSet size to be decreased once the remove completes.
 func (c *M3DBController) shrinkPlacementForSet(cluster *myspec.M3DBCluster, set *appsv1.StatefulSet, pl placement.Placement) error {
+	if cluster.Spec.PreventScaleDown {
+		return pkgerrors.Errorf("cannot remove nodes from %s/%s, preventScaleDown is true", cluster.Namespace, cluster.Name)
+	}
+
 	selector := klabels.SelectorFromSet(set.Labels)
 	pods, err := c.podLister.Pods(cluster.Namespace).List(selector)
 	if err != nil {

--- a/pkg/controller/update_cluster.go
+++ b/pkg/controller/update_cluster.go
@@ -516,7 +516,8 @@ func (c *M3DBController) expandPlacementForSet(cluster *myspec.M3DBCluster, set 
 // the StatefulSet size to be decreased once the remove completes.
 func (c *M3DBController) shrinkPlacementForSet(cluster *myspec.M3DBCluster, set *appsv1.StatefulSet, pl placement.Placement) error {
 	if cluster.Spec.PreventScaleDown {
-		return pkgerrors.Errorf("cannot remove nodes from %s/%s, preventScaleDown is true", cluster.Namespace, cluster.Name)
+		return pkgerrors.Errorf("cannot remove nodes from %s/%s, preventScaleDown is true",
+			cluster.Namespace, cluster.Name)
 	}
 
 	selector := klabels.SelectorFromSet(set.Labels)


### PR DESCRIPTION
Scaling down an M3DB cluster is a pretty heavy operation. All nodes in
the cluster must restream data, and it can put unnecessary pressure on a
cluster if accidentally triggered.

This PR adds a flag that allows users to ensure a cluster will not be
scaled down.

Thanks for contributing to the M3DB Operator! We'd love to accept your contribution, but we require that most issues
outside of trivial changes such as typo corrections have an issue associated with the pull request. So please [open an
issue](https://github.com/m3db/m3db-operator/issues/new) first!
