### PR TITLE
Update manifests to include latest required RBAC permissions for statefulsets

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -31,7 +31,7 @@ rules:
   resources: ["pods"]
   verbs: ["list", "get", "watch", "update", "patch"]
 - apiGroups: ["apps"]
-  resources: ["statefulsets", "deployments"]
+  resources: ["statefulsets", "statefulsets/status", "deployments"]
   verbs: ["*"]
 - apiGroups: ["operator.m3db.io"]
   resources: ["*"]

--- a/helm/m3db-operator/templates/cluster_role.yaml
+++ b/helm/m3db-operator/templates/cluster_role.yaml
@@ -22,7 +22,7 @@ rules:
   resources: ["pods"]
   verbs: ["list", "get", "watch", "update", "patch"]
 - apiGroups: ["apps"]
-  resources: ["statefulsets", "deployments"]
+  resources: ["statefulsets", "statefulsets/status", "deployments"]
   verbs: ["*"]
 - apiGroups: ["operator.m3db.io"]
   resources: ["*"]

--- a/integration/manifests/operator.yaml
+++ b/integration/manifests/operator.yaml
@@ -28,7 +28,7 @@ rules:
   resources: ["pods"]
   verbs: ["list", "get", "watch", "update", "patch"]
 - apiGroups: ["apps"]
-  resources: ["statefulsets", "deployments"]
+  resources: ["statefulsets", "statefulsets/status", "deployments"]
   verbs: ["*"]
 - apiGroups: ["operator.m3db.io"]
   resources: ["*"]


### PR DESCRIPTION
Fixing operator error like this: 

`E1017 04:50:00.170828       1 controller.go:327] error syncing cluster 'default/m3db-cluster-prod-30day': statefulsets.apps "m3db-cluster-prod-30day-rep0" is forbidden: User "system:serviceaccount:default:m3db-operator" cannot update resource "statefulsets/status" in API group "apps" in the namespace "default"`