### PR TITLE
Update to Go 1.16

### DIFF
--- a/.buildkite/Dockerfile-ci
+++ b/.buildkite/Dockerfile-ci
@@ -1,4 +1,4 @@
-FROM golang:1.13-stretch
+FROM golang:1.16-stretch
 
 RUN mkdir /helm && \
   cd /helm && \

--- a/.buildkite/pipeline-test-e2e.yml
+++ b/.buildkite/pipeline-test-e2e.yml
@@ -3,7 +3,7 @@ steps:
     command: make clean test-e2e
     env:
       CGO_ENABLED: 0
-      GIMME_GO_VERSION: 1.13.x
+      GIMME_GO_VERSION: 1.16.x
     plugins:
       gopath-checkout#v1.0.1:
         import: github.com/m3db/m3db-operator

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # stage 1: build
-FROM golang:1.13-alpine AS builder
+FROM golang:1.16-alpine AS builder
 LABEL maintainer="The m3db-operator Authors <m3db@googlegroups.com>"
 
 # Install CA certs for curl
@@ -15,8 +15,8 @@ ADD . /go/src/github.com/m3db/m3db-operator
 
 # Build m3dbnode binary
 RUN cd /go/src/github.com/m3db/m3db-operator/ && \
-    git submodule update --init      && \
-    make m3db-operator
+  git submodule update --init      && \
+  make m3db-operator
 
 # stage 2: lightweight "release"
 FROM alpine:latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/m3db/m3db-operator
 
-go 1.13
+go 1.16
 
 require (
 	github.com/ant31/crd-validation v0.0.0-20180801212718-38f6a293f140

--- a/go.sum
+++ b/go.sum
@@ -243,7 +243,6 @@ github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
-github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.2.1-0.20180901000122-b433bbd6d743/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=


### PR DESCRIPTION
This commit updates the m3db-operator to Go version 1.16.
