### PR TITLE
Use golang:1.16-alpine3.13 as build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # stage 1: build
-FROM golang:1.16-alpine AS builder
+FROM golang:1.16-alpine3.13 AS builder
 LABEL maintainer="The m3db-operator Authors <m3db@googlegroups.com>"
 
 # Install CA certs for curl


### PR DESCRIPTION
This commit updates the Docker image we use to build the m3db-operator to `golang:1.16-alpine3.13`. The current image, `golang:1.16-alpine`, uses Alpine 3.14 which requires at least Docker 20.10.0 in order to pick up [a fix for an issue with the faccessat2 syscall in Alpine Linux 3.14](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2). Longer term we should update CI to use a newer version of Docker but in the interim this commit just uses an image with Alpine 3.13.