### PR TITLE
[ci] Set PUSH_SHA_TAG env var to true

### DIFF
--- a/.buildkite/image-release-pipeline.yml
+++ b/.buildkite/image-release-pipeline.yml
@@ -4,6 +4,7 @@ steps:
     command: ".ci/docker/build.sh"
     env:
       M3_DOCKER_REPO: quay.io/m3db
+      PUSH_SHA_TAG: true
     agents:
       queue: builders
     timeout_in_minutes: 60
@@ -20,6 +21,7 @@ steps:
     command: ".ci/docker/build.sh"
     env:
       M3_DOCKER_REPO: quay.io/m3
+      PUSH_SHA_TAG: true
     agents:
       queue: builders
     timeout_in_minutes: 60


### PR DESCRIPTION
This commit sets the `PUSH_SHA_TAG` environment variable to true in our CI jobs that upload Docker images to ensure they tag the images with the SHA of the commit that the images were built from.
