### PR TITLE
[WIP] switch from apiextensionsv1beta1 to apiextensionsv1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/m3db/m3db-operator
 go 1.16
 
 require (
-	github.com/ant31/crd-validation v0.0.0-20180801212718-38f6a293f140
+	github.com/abdulmi/crd-validation v0.0.0-20220609021037-be9bd8047a8d
+	github.com/ant31/crd-validation v0.0.0-20180801212718-38f6a293f140 // indirect
 	github.com/apex/log v1.3.0 // indirect
 	github.com/axw/gocov v1.0.0
 	github.com/bmatcuk/doublestar v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrU
 github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/abdulmi/crd-validation v0.0.0-20220609021037-be9bd8047a8d h1:1Miq3mhdkEtuoWxqNZWhmjWwBeeeiHlL2x+Wi338P2I=
+github.com/abdulmi/crd-validation v0.0.0-20220609021037-be9bd8047a8d/go.mod h1:A8UHRgmyhPXyur6USEH7TLVyFsQRzP7CJ2fF6Lu9ncQ=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=

--- a/pkg/k8sops/m3db/crd.go
+++ b/pkg/k8sops/m3db/crd.go
@@ -43,7 +43,7 @@ func (k *k8sWrapper) CreateOrUpdateCRD(
 		return fmt.Errorf("unrecognized CRD name '%s'", name)
 	}
 
-	crdClient := k.kubeExt.ApiextensionsV1beta1().CustomResourceDefinitions()
+	crdClient := k.kubeExt.ApiextensionsV1().CustomResourceDefinitions()
 	curCRD, err := crdClient.Get(ctx, name, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return pkgerrors.WithMessagef(err, "could not fetch CRD '%s'", name)

--- a/pkg/k8sops/m3db/crd_test.go
+++ b/pkg/k8sops/m3db/crd_test.go
@@ -28,7 +28,7 @@ import (
 	m3dboperator "github.com/m3db/m3db-operator/pkg/apis/m3dboperator"
 	myspec "github.com/m3db/m3db-operator/pkg/apis/m3dboperator/v1alpha1"
 	clientsetFake "github.com/m3db/m3db-operator/pkg/client/clientset/versioned/fake"
-	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kubeExtFake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +46,7 @@ func TestCreateOrUpdateCRD(t *testing.T) {
 	err := k.CreateOrUpdateCRD(ctx, "foo", false)
 	assert.Error(t, err)
 
-	ext := k.kubeExt.ApiextensionsV1beta1().CustomResourceDefinitions()
+	ext := k.kubeExt.ApiextensionsV1().CustomResourceDefinitions()
 	// Ensure CRD didn't exist before but exists after
 	_, err = ext.Get(ctx, m3dboperator.M3DBClustersName, metav1.GetOptions{})
 	assert.Error(t, err)
@@ -86,7 +86,7 @@ func TestCreateOrUpdateCRD_Err(t *testing.T) {
 			ctx := context.Background()
 
 			k.kubeExt.(*kubeExtFake.Clientset).Fake.PrependReactor(test.action, "*", func(action ktesting.Action) (bool, runtime.Object, error) {
-				return true, &extv1beta1.CustomResourceDefinition{}, errors.New("test")
+				return true, &extv1.CustomResourceDefinition{}, errors.New("test")
 			})
 
 			// Must create CRD first to have an error updating it.

--- a/pkg/k8sops/m3db/generators.go
+++ b/pkg/k8sops/m3db/generators.go
@@ -34,7 +34,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	crdutils "github.com/ant31/crd-validation/pkg"
+	// crdutils "github.com/ant31/crd-validation/pkg"
 	pkgerrors "github.com/pkg/errors"
 	"k8s.io/utils/pointer"
 )
@@ -109,9 +109,9 @@ func GenerateCRD(enableValidation bool) *apiextensionsv1.CustomResourceDefinitio
 		},
 	}
 
-	if enableValidation {
-		crd.Spec.Validation = crdutils.GetCustomResourceValidation(_openAPISpecName, myspec.GetOpenAPIDefinitions)
-	}
+	// if enableValidation {
+	// 	crd.Spec.Versions[0].Schema.openAPIV3Schema = crdutils.GetCustomResourceValidation(_openAPISpecName, myspec.GetOpenAPIDefinitions)
+	// }
 
 	return crd
 }

--- a/pkg/k8sops/m3db/generators.go
+++ b/pkg/k8sops/m3db/generators.go
@@ -34,7 +34,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	// crdutils "github.com/ant31/crd-validation/pkg"
+	crdutils "github.com/abdulmi/crd-validation/pkg"
 	pkgerrors "github.com/pkg/errors"
 	"k8s.io/utils/pointer"
 )
@@ -99,6 +99,7 @@ func GenerateCRD(enableValidation bool) *apiextensionsv1.CustomResourceDefinitio
 					Subresources: &apiextensionsv1.CustomResourceSubresources{
 						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
 					},
+					Schema: crdutils.GetCustomResourceValidation(_openAPISpecName, myspec.GetOpenAPIDefinitions),
 				},
 			},
 			Scope: apiextensionsv1.NamespaceScoped,
@@ -107,12 +108,6 @@ func GenerateCRD(enableValidation bool) *apiextensionsv1.CustomResourceDefinitio
 				Kind:   m3dboperator.M3DBClusterResourceKind,
 			},
 		},
-	}
-
-	if enableValidation {
-		crd.Spec.Versions[0].Schema = &apiextensionsv1.CustomResourceValidation{
-			OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{Description: "hello world"},
-		}
 	}
 
 	return crd

--- a/pkg/k8sops/m3db/generators.go
+++ b/pkg/k8sops/m3db/generators.go
@@ -31,7 +31,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	crdutils "github.com/ant31/crd-validation/pkg"
@@ -84,27 +84,27 @@ var baseCoordinatorPorts = [...]m3dbPort{
 var carbonListenerPort = m3dbPort{"coord-carbon", PortM3CoordinatorCarbon, v1.ProtocolTCP}
 
 // GenerateCRD generates the crd object needed for the M3DBCluster
-func GenerateCRD(enableValidation bool) *apiextensionsv1beta1.CustomResourceDefinition {
-	crd := &apiextensionsv1beta1.CustomResourceDefinition{
+func GenerateCRD(enableValidation bool) *apiextensionsv1.CustomResourceDefinition {
+	crd := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: m3dboperator.M3DBClustersName,
 		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 			Group: m3dboperator.GroupName,
-			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{
 					Name:    m3dboperator.Version,
 					Served:  true,
 					Storage: true,
+					Subresources: &apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+					},
 				},
 			},
-			Scope: apiextensionsv1beta1.NamespaceScoped,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
 				Plural: m3dboperator.M3DBClusterResourcePlural,
 				Kind:   m3dboperator.M3DBClusterResourceKind,
-			},
-			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
-				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
 			},
 		},
 	}

--- a/pkg/k8sops/m3db/generators.go
+++ b/pkg/k8sops/m3db/generators.go
@@ -109,9 +109,11 @@ func GenerateCRD(enableValidation bool) *apiextensionsv1.CustomResourceDefinitio
 		},
 	}
 
-	// if enableValidation {
-	// 	crd.Spec.Versions[0].Schema.openAPIV3Schema = crdutils.GetCustomResourceValidation(_openAPISpecName, myspec.GetOpenAPIDefinitions)
-	// }
+	if enableValidation {
+		crd.Spec.Versions[0].Schema = &apiextensionsv1.CustomResourceValidation{
+			OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{Description: "hello world"},
+		}
+	}
 
 	return crd
 }

--- a/pkg/k8sops/m3db/generators_test.go
+++ b/pkg/k8sops/m3db/generators_test.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 
-	crdutils "github.com/ant31/crd-validation/pkg"
+	crdutils "github.com/abdulmi/crd-validation/pkg"
 	"github.com/d4l3k/messagediff"
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/k8sops/m3db/generators_test.go
+++ b/pkg/k8sops/m3db/generators_test.go
@@ -30,7 +30,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -43,26 +43,26 @@ import (
 )
 
 func TestGenerateCRD(t *testing.T) {
-	crd := &apiextensionsv1beta1.CustomResourceDefinition{
+	crd := &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: m3dboperator.M3DBClustersName,
 		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 			Group: m3dboperator.GroupName,
-			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 				{
 					Name:    m3dboperator.Version,
 					Served:  true,
 					Storage: true,
+					Subresources: &apiextensionsv1.CustomResourceSubresources{
+						Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+					},
 				},
 			},
-			Scope: apiextensionsv1beta1.NamespaceScoped,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
 				Plural: m3dboperator.M3DBClusterResourcePlural,
 				Kind:   m3dboperator.M3DBClusterResourceKind,
-			},
-			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
-				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
 			},
 		},
 	}


### PR DESCRIPTION
Issue: https://github.com/m3db/m3db-operator/issues/323

Switching from apiextensionsv1beta1 to apiextensionsv1 to make m3db-operator compatible with kubernetes 1.22 (kubernetes 1.21 has EOL in July 2022 in AKS :()