### PR TITLE
[api] schema: extendedOptions as untyped object

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -3382,14 +3382,8 @@ spec:
                             options.
                           properties:
                             options:
-                              additionalProperties:
-                                description: RawMessage is a raw encoded JSON value.
-                                  It implements Marshaler and Unmarshaler and can
-                                  be used to delay JSON decoding or precompute a JSON
-                                  encoding.
-                                format: byte
-                                type: string
                               type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             type:
                               type: string
                           type: object

--- a/helm/m3db-operator/templates/00_operator.m3db.io_m3dbclusters.yaml
+++ b/helm/m3db-operator/templates/00_operator.m3db.io_m3dbclusters.yaml
@@ -3374,14 +3374,8 @@ spec:
                             options.
                           properties:
                             options:
-                              additionalProperties:
-                                description: RawMessage is a raw encoded JSON value.
-                                  It implements Marshaler and Unmarshaler and can
-                                  be used to delay JSON decoding or precompute a JSON
-                                  encoding.
-                                format: byte
-                                type: string
                               type: object
+                              x-kubernetes-preserve-unknown-fields: true
                             type:
                               type: string
                           type: object

--- a/pkg/apis/m3dboperator/v1alpha1/namespace.go
+++ b/pkg/apis/m3dboperator/v1alpha1/namespace.go
@@ -102,7 +102,10 @@ type DownsampleOptions struct {
 
 // ExtendedOptions stores the extended namespace options.
 type ExtendedOptions struct {
-	Type    string                     `json:"type,omitempty"`
+	Type string `json:"type,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:validation:Type=object
 	Options map[string]json.RawMessage `json:"options,omitempty"`
 }
 


### PR DESCRIPTION
`extendedOptions` are used to store unstructured metadata. This PR
ensures the OpenAPI schema reflects that.
