### PR TITLE
[crd] Ensure schema has embedded metadata fields

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -103,6 +103,23 @@ spec:
                     type: string
                   metadata:
                     description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
                     type: object
                   spec:
                     description: 'spec defines the desired characteristics of a volume
@@ -2168,6 +2185,23 @@ spec:
                               description: May contain labels and annotations that
                                 will be copied into the PVC when creating it. No other
                                 fields are allowed and will be rejected during validation.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
                               type: object
                             spec:
                               description: The specification for the PersistentVolumeClaim.
@@ -3486,6 +3520,23 @@ spec:
                 description: PodMetadata is for any Metadata that is unique to the
                   pods, and does not belong on any other objects, such as Prometheus
                   scrape tags
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  finalizers:
+                    items:
+                      type: string
+                    type: array
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  name:
+                    type: string
+                  namespace:
+                    type: string
                 type: object
               podSecurityContext:
                 description: PodSecurityContext allows the user to specify an optional
@@ -5478,6 +5529,23 @@ spec:
                               description: May contain labels and annotations that
                                 will be copied into the PVC when creating it. No other
                                 fields are allowed and will be rejected during validation.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
                               type: object
                             spec:
                               description: The specification for the PersistentVolumeClaim.

--- a/hack/update-generated.sh
+++ b/hack/update-generated.sh
@@ -31,7 +31,7 @@ chmod +x "$GEN_GROUPS"
   "$@"
 
 # Generate CRD spec and schema.
-controller-gen crd paths=./pkg/apis/m3dboperator/v1alpha1/ +output:dir=helm/m3db-operator/templates
+controller-gen crd:generateEmbeddedObjectMeta=true paths=./pkg/apis/m3dboperator/v1alpha1/ +output:dir=helm/m3db-operator/templates
 
 # Ensure helm bundles the CRD first.
 (

--- a/helm/m3db-operator/templates/00_operator.m3db.io_m3dbclusters.yaml
+++ b/helm/m3db-operator/templates/00_operator.m3db.io_m3dbclusters.yaml
@@ -95,6 +95,23 @@ spec:
                     type: string
                   metadata:
                     description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
                     type: object
                   spec:
                     description: 'spec defines the desired characteristics of a volume
@@ -2160,6 +2177,23 @@ spec:
                               description: May contain labels and annotations that
                                 will be copied into the PVC when creating it. No other
                                 fields are allowed and will be rejected during validation.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
                               type: object
                             spec:
                               description: The specification for the PersistentVolumeClaim.
@@ -3478,6 +3512,23 @@ spec:
                 description: PodMetadata is for any Metadata that is unique to the
                   pods, and does not belong on any other objects, such as Prometheus
                   scrape tags
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  finalizers:
+                    items:
+                      type: string
+                    type: array
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  name:
+                    type: string
+                  namespace:
+                    type: string
                 type: object
               podSecurityContext:
                 description: PodSecurityContext allows the user to specify an optional
@@ -5470,6 +5521,23 @@ spec:
                               description: May contain labels and annotations that
                                 will be copied into the PVC when creating it. No other
                                 fields are allowed and will be rejected during validation.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
                               type: object
                             spec:
                               description: The specification for the PersistentVolumeClaim.


### PR DESCRIPTION
Generating CRDs without `generateEmbeddedObjectMeta=true` means that
when embedding standard types, such as pod metadata or PVC metadata, the
schema for metadata was not being included in the CRD.

This PR ensures we generate the CRDs with all necessary embedded
metadata.
