### PR TITLE
Clean up unused PVCs

### DIFF
--- a/cmd/m3db-operator/main.go
+++ b/cmd/m3db-operator/main.go
@@ -84,6 +84,9 @@ func init() {
 	flag.Parse()
 }
 
+// TODO: add flag to disable it
+// TODO: we can have an annotation when the last successful loop was executed
+// TODO: include dry-run
 func main() {
 	var cfg zap.Config
 	if _develLog {

--- a/cmd/m3db-operator/main.go
+++ b/cmd/m3db-operator/main.go
@@ -244,6 +244,17 @@ func main() {
 	go filteredInformerFactory.Start(stopCh)
 	go m3dbClusterInformerFactory.Start(stopCh)
 
+	go func() {
+		for {
+			select {
+			case <-time.After(60 * time.Second):
+				logger.Info("Correct build running!")
+			case <-stopCh:
+				return
+			}
+		}
+	}()
+
 	// Trap the INT and TERM signals
 	signalChan := make(chan os.Signal, 2)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/m3db-operator/main.go
+++ b/cmd/m3db-operator/main.go
@@ -244,17 +244,6 @@ func main() {
 	go filteredInformerFactory.Start(stopCh)
 	go m3dbClusterInformerFactory.Start(stopCh)
 
-	go func() {
-		for {
-			select {
-			case <-time.After(60 * time.Second):
-				logger.Info("Correct build running!")
-			case <-stopCh:
-				return
-			}
-		}
-	}()
-
 	// Trap the INT and TERM signals
 	signalChan := make(chan os.Signal, 2)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/m3db-operator/main.go
+++ b/cmd/m3db-operator/main.go
@@ -84,9 +84,6 @@ func init() {
 	flag.Parse()
 }
 
-// TODO: add flag to disable it
-// TODO: we can have an annotation when the last successful loop was executed
-// TODO: include dry-run
 func main() {
 	var cfg zap.Config
 	if _develLog {

--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -63,6 +63,7 @@ type testDeps struct {
 	statefulSetLister appsv1listers.StatefulSetLister
 	podLister         corev1listers.PodLister
 	crdLister         crdlisters.M3DBClusterLister
+	pvcLister         corev1listers.PersistentVolumeClaimLister
 	placementClient   *placement.MockClient
 	namespaceClient   *namespace.MockClient
 	clock             clock.Clock
@@ -109,6 +110,8 @@ func (deps *testDeps) newController(t *testing.T) *M3DBController {
 
 		clusterWorkQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), clusterWorkQueueName),
 		clusterLister:    deps.crdLister,
+
+		pvcLister: deps.pvcLister,
 	}
 }
 
@@ -139,6 +142,7 @@ func newTestDeps(t *testing.T, opts *testOpts) *testDeps {
 	kubeInformers := kubeinformers.NewSharedInformerFactory(deps.kubeClient, 0)
 	sets := kubeInformers.Apps().V1().StatefulSets()
 	pods := kubeInformers.Core().V1().Pods()
+	pvcs := kubeInformers.Core().V1().PersistentVolumeClaims()
 
 	crdInformers := crdinformers.NewSharedInformerFactory(deps.crdClient, 0)
 	crds := crdInformers.Operator().V1alpha1().M3DBClusters()
@@ -146,6 +150,7 @@ func newTestDeps(t *testing.T, opts *testOpts) *testDeps {
 	deps.statefulSetLister = sets.Lister()
 	deps.podLister = pods.Lister()
 	deps.crdLister = crds.Lister()
+	deps.pvcLister = pvcs.Lister()
 
 	go kubeInformers.Start(deps.stopCh)
 	go crdInformers.Start(deps.stopCh)

--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -161,6 +161,7 @@ func newTestDeps(t *testing.T, opts *testOpts) *testDeps {
 			sets.Informer().HasSynced,
 			pods.Informer().HasSynced,
 			crds.Informer().HasSynced,
+			pvcs.Informer().HasSynced,
 		)
 	}()
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -31,6 +31,19 @@ import (
 	"strings"
 	"sync"
 
+	myspec "github.com/m3db/m3db-operator/pkg/apis/m3dboperator/v1alpha1"
+	clientset "github.com/m3db/m3db-operator/pkg/client/clientset/versioned"
+	samplescheme "github.com/m3db/m3db-operator/pkg/client/clientset/versioned/scheme"
+	clusterlisters "github.com/m3db/m3db-operator/pkg/client/listers/m3dboperator/v1alpha1"
+	"github.com/m3db/m3db-operator/pkg/k8sops/annotations"
+	"github.com/m3db/m3db-operator/pkg/k8sops/labels"
+	"github.com/m3db/m3db-operator/pkg/k8sops/m3db"
+	"github.com/m3db/m3db-operator/pkg/k8sops/podidentity"
+	"github.com/m3db/m3db-operator/pkg/m3admin"
+	"github.com/m3db/m3db-operator/pkg/util/eventer"
+
+	m3placement "github.com/m3db/m3/src/cluster/placement"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -50,21 +63,9 @@ import (
 	"k8s.io/utils/pointer"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	m3placement "github.com/m3db/m3/src/cluster/placement"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
-
-	myspec "github.com/m3db/m3db-operator/pkg/apis/m3dboperator/v1alpha1"
-	clientset "github.com/m3db/m3db-operator/pkg/client/clientset/versioned"
-	samplescheme "github.com/m3db/m3db-operator/pkg/client/clientset/versioned/scheme"
-	clusterlisters "github.com/m3db/m3db-operator/pkg/client/listers/m3dboperator/v1alpha1"
-	"github.com/m3db/m3db-operator/pkg/k8sops/annotations"
-	"github.com/m3db/m3db-operator/pkg/k8sops/labels"
-	"github.com/m3db/m3db-operator/pkg/k8sops/m3db"
-	"github.com/m3db/m3db-operator/pkg/k8sops/podidentity"
-	"github.com/m3db/m3db-operator/pkg/m3admin"
-	"github.com/m3db/m3db-operator/pkg/util/eventer"
 )
 
 const (

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1344,7 +1344,7 @@ func (c *M3DBController) cleanupUnusedStorageForSts(ctx context.Context, cluster
 		}
 
 		// Sometimes a PV can have a reclaim policy other than "Delete". Skip these PVCs,
-		// so we would not leave dangling PV which are hard to select because of the missing labels.
+		// so we would not leave dangling PVs which are hard to select because of the missing labels.
 		if pv.Spec.PersistentVolumeReclaimPolicy != corev1.PersistentVolumeReclaimDelete {
 			logger.Warn("PVC has a PV with a non-delete reclaim policy. Skipping it to avoid leaving dangling PVs",
 				zap.String("pvc", pvc.Name),

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -214,7 +214,9 @@ func waitForStatefulSets(
 			sts = action.(kubetesting.UpdateActionImpl).GetObject().(*appsv1.StatefulSet)
 			// Note: Simulate an update revision to make sure the updated
 			// replicas check is enforced.
+			mu.Lock()
 			updates++
+			mu.Unlock()
 			sts.Status.UpdateRevision = fmt.Sprintf("updated-revision-%d", updates)
 			sts.Status.CurrentRevision = fmt.Sprintf("%s-%s", sts.Name, opts.currentRevision)
 			if !opts.simulatePodsNotUpdated {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -214,9 +214,7 @@ func waitForStatefulSets(
 			sts = action.(kubetesting.UpdateActionImpl).GetObject().(*appsv1.StatefulSet)
 			// Note: Simulate an update revision to make sure the updated
 			// replicas check is enforced.
-			mu.Lock()
 			updates++
-			mu.Unlock()
 			sts.Status.UpdateRevision = fmt.Sprintf("updated-revision-%d", updates)
 			sts.Status.CurrentRevision = fmt.Sprintf("%s-%s", sts.Name, opts.currentRevision)
 			if !opts.simulatePodsNotUpdated {

--- a/pkg/util/eventer/eventer.go
+++ b/pkg/util/eventer/eventer.go
@@ -61,6 +61,9 @@ const (
 	ReasonFailSync    = "FailedToSync"
 	ReasonSuccessSync = "SuccessfulSync"
 
+	// Disk management events
+	ReasonPVCDeleted = "PVCDeleted"
+
 	// Misc events
 	ReasonLongerThanUsual = "TimeLongerThanUsual"
 	ReasonUnknown         = "Unknown"


### PR DESCRIPTION
After shrinking the cluster, allocated PVCs for the removed pods are not deleted at the moment. 

This PR will add a step to the controller loop which will check each cluster's STS if there are any unused PVCs assigned and will delete them.